### PR TITLE
Multiply by the scale, not divide

### DIFF
--- a/n3fit/src/n3fit/layers/CombineCfac.py
+++ b/n3fit/src/n3fit/layers/CombineCfac.py
@@ -61,7 +61,7 @@ class CombineCfacLayer(Layer):
         self.scales = np.array(scales, dtype=np.float32)
         if len(initial_values) > 0:
             initial_values = tf.concat(initial_values, 0)
-            initial_values = tf.math.divide(initial_values, self.scales)
+            initial_values = tf.math.multiply(initial_values, self.scales)
 
             self.w = tf.Variable(
                 initial_value=initial_values,


### PR DESCRIPTION
This PR solves a bug (introduced here #40 ) regarding the initialisation of the WC.

If the values from the table are divided by the scale, the Wilson coefficient needs to be multiplied, so that the theoretical prediction given by
c * lin = (c * scale) * (lin / scale) = c' * lin' 

Note that this was not noted in the previous PR since initialisation was starting from zero.