### PR TITLE
Pineparser for compatibility with new theories

### DIFF
--- a/validphys2/src/validphys/commondataparser.py
+++ b/validphys2/src/validphys/commondataparser.py
@@ -13,6 +13,8 @@ import pandas as pd
 from validphys.core import peek_commondata_metadata
 from validphys.coredata import CommonData
 
+EXT = "pineappl.lz4"
+
 def load_commondata(spec):
     """
     Load the data corresponding to a CommonDataSpec object.

--- a/validphys2/src/validphys/core.py
+++ b/validphys2/src/validphys/core.py
@@ -572,12 +572,27 @@ class DataSetSpec(TupleComp):
         return self.name
 
 class FKTableSpec(TupleComp):
-    def __init__(self, fkpath, cfactors, use_fixed_predictions=False, fixed_predictions_path=None):
+    def __init__(self, fkpath, cfactors, use_fixed_predictions=False, fixed_predictions_path=None, metadata=None):
         self.fkpath = fkpath
-        self.cfactors = cfactors
+        self.cfactors = cfactors if cfactors is not None else []
+        self.legacy = False
         self.use_fixed_predictions = use_fixed_predictions
         self.fixed_predictions_path = fixed_predictions_path
-        super().__init__(fkpath, cfactors)
+
+        if not isinstance(fkpath, (tuple, list)):
+            self.legacy = True
+        else:
+            fkpath = tuple(fkpath)
+        
+        self.metadata = metadata
+
+        # For non-legacy theory, add the metadata since it defines how the theory is to be loaded
+        # and thus, it should also define the hash of the class
+        if not self.legacy:
+            super().__init__(fkpath, cfactors, self.metadata)
+        else:
+            super().__init__(fkpath, cfactors)
+        
 
     #NOTE: We cannot do this because Fkset owns the fktable, and trying
     #to reuse the loaded one fails after it gets deleted.

--- a/validphys2/src/validphys/coredata.py
+++ b/validphys2/src/validphys/coredata.py
@@ -140,6 +140,24 @@ class FKTableData:
             fktable = fk_raw.reshape((nx, nbasis, ndata)).T
 
         return fktable
+    
+    
+    @property
+    def luminosity_mapping(self):
+        """Return the flavour combinations that contribute to the fktable
+        in the form of a single array
+
+        The return shape is:
+            (nbasis,) for DIS
+            (nbasis*2,) for hadronic
+        """
+        basis = self.sigma.columns.to_numpy()
+        if self.hadronic:
+            ret = np.zeros(14 * 14, dtype=bool)
+            ret[basis] = True
+            basis = np.array(np.where(ret.reshape(14, 14))).T.reshape(-1)
+        return basis
+
 
 
 @dataclasses.dataclass(eq=False)

--- a/validphys2/src/validphys/fkparser.py
+++ b/validphys2/src/validphys/fkparser.py
@@ -29,6 +29,7 @@ import numpy as np
 import pandas as pd
 
 from validphys.coredata import FKTableData, CFactorData
+from validphys.pineparser import pineappl_reader
 
 
 
@@ -53,8 +54,13 @@ class GridInfo:
 def load_fktable(spec):
     """Load the data corresponding to a FKSpec object. The cfactors
     will be applied to the grid."""
-    with open_fkpath(spec.fkpath) as handle:
-        tabledata = parse_fktable(handle)
+    if spec.legacy:
+        with open_fkpath(spec.fkpath) as handle:
+            tabledata = parse_fktable(handle)
+    
+    else:
+        tabledata = pineappl_reader(spec)
+    
     if not spec.cfactors:
         return tabledata
 

--- a/validphys2/src/validphys/n3fit_data.py
+++ b/validphys2/src/validphys/n3fit_data.py
@@ -180,11 +180,20 @@ def _mask_fk_tables(dataset_dicts, tr_masks):
         vl_fks = []
         ex_fks = []
         vl_mask = ~tr_mask
+        
         for fktable_dict in dataset_dict["fktables"]:
-            tr_fks.append(fktable_dict["fktable"][tr_mask])
-            vl_fks.append(fktable_dict["fktable"][vl_mask])
-            ex_fks.append(fktable_dict.get("fktable"))
-            dataset_dict['ds_tr_mask'] = tr_mask
+            if not dataset_dict["use_fixed_predictions"]:
+                tr_fks.append(fktable_dict["fktable"][tr_mask])
+                vl_fks.append(fktable_dict["fktable"][vl_mask])
+                ex_fks.append(fktable_dict.get("fktable"))
+                dataset_dict['ds_tr_mask'] = tr_mask
+            # note: fixed observables have a fake fktable
+            else:
+                tr_fks.append(fktable_dict["fktable"])
+                vl_fks.append([])
+                ex_fks.append(fktable_dict.get("fktable"))
+                dataset_dict['ds_tr_mask'] = tr_mask
+
         dataset_dict["tr_fktables"] = tr_fks
         dataset_dict["vl_fktables"] = vl_fks
         dataset_dict["ex_fktables"] = ex_fks

--- a/validphys2/src/validphys/n3fit_data_utils.py
+++ b/validphys2/src/validphys/n3fit_data_utils.py
@@ -89,11 +89,18 @@ def new_fk_parser(fkspec, is_hadronic=False):
     """
     fktable_data = load_fktable(fkspec)
     ndata = fktable_data.ndata
-    xgrid = fktable_data.xgrid
+    xgrid_flat = fktable_data.xgrid
+    nx = len(xgrid_flat)
+
+    if is_hadronic:
+        xgrid = xgrid_flat.reshape(1, nx)
+    else:
+        xgrid = xgrid_flat.reshape(1, nx)
+        
     # n of active flavours
     basis = fktable_data.luminosity_mapping
     nbasis = len(basis)
-    nx = len(xgrid)
+    
     fktable = fktable_data.get_np_fktable()
 
     dict_out = {

--- a/validphys2/src/validphys/n3fit_data_utils.py
+++ b/validphys2/src/validphys/n3fit_data_utils.py
@@ -74,7 +74,7 @@ def fk_parser(fk, is_hadronic=False):
 
     return dict_out
 
-def new_fk_parser(fkspec, is_hadronic=False):
+def new_fk_parser(fkspec, cuts, is_hadronic=False):
     """
     # Arguments:
         - `fkspec`: fkspec object
@@ -87,15 +87,15 @@ def new_fk_parser(fkspec, is_hadronic=False):
             - 'basis'
             - 'fktable'
     """
-    fktable_data = load_fktable(fkspec)
+    if cuts:
+        fktable_data = load_fktable(fkspec).with_cuts(cuts)
+    else:
+        fktable_data = load_fktable(fkspec)
     ndata = fktable_data.ndata
     xgrid_flat = fktable_data.xgrid
     nx = len(xgrid_flat)
 
-    if is_hadronic:
-        xgrid = xgrid_flat.reshape(1, nx)
-    else:
-        xgrid = xgrid_flat.reshape(1, nx)
+    xgrid = xgrid_flat.reshape(1, nx)
         
     # n of active flavours
     basis = fktable_data.luminosity_mapping
@@ -194,7 +194,7 @@ def common_data_reader_dataset(dataset_c, dataset_spec):
     how_many = dataset_c.GetNSigma()
     dict_fktables = []
     for fkspec in dataset_spec.fkspecs:
-        dict_fktables.append(new_fk_parser(fkspec, dataset_c.IsHadronic()))
+        dict_fktables.append(new_fk_parser(fkspec, cuts, dataset_c.IsHadronic()))
 
     # for i in range(how_many):
     #     fktable = dataset_c.GetFK(i)
@@ -241,7 +241,7 @@ def positivity_reader(pos_spec):
 
     # assuming that all positivity sets have only one fktable
     # parsed_set = [fk_parser(pos_c, pos_c.IsHadronic())]
-    parsed_set = [new_fk_parser(pos_spec.fkspecs[0], pos_c.IsHadronic())]
+    parsed_set = [new_fk_parser(pos_spec.fkspecs[0], cuts=False, is_hadronic=pos_c.IsHadronic())]
 
     pos_sets = [
         {

--- a/validphys2/src/validphys/n3fit_data_utils.py
+++ b/validphys2/src/validphys/n3fit_data_utils.py
@@ -87,14 +87,14 @@ def new_fk_parser(fkspec, is_hadronic=False):
             - 'basis'
             - 'fktable'
     """
-    fktable = load_fktable(fkspec)
-    ndata = fktable.ndata
-    xgrid = fktable.xgrid
+    fktable_data = load_fktable(fkspec)
+    ndata = fktable_data.ndata
+    xgrid = fktable_data.xgrid
     # n of active flavours
-    nbasis = len(fktable.sigma.columns)
-    basis = fktable.sigma.columns.to_numpy()
+    basis = fktable_data.luminosity_mapping
+    nbasis = len(basis)
     nx = len(xgrid)
-    fktable = fktable.get_np_fktable()
+    fktable = fktable_data.get_np_fktable()
 
     dict_out = {
         "ndata": ndata,

--- a/validphys2/src/validphys/n3fit_data_utils.py
+++ b/validphys2/src/validphys/n3fit_data_utils.py
@@ -87,7 +87,10 @@ def new_fk_parser(fkspec, cuts, is_hadronic=False):
             - 'basis'
             - 'fktable'
     """
-    if cuts:
+    # for fixed predictions the same fake fktable is always loaded
+    if fkspec.use_fixed_predictions:
+        fktable_data = load_fktable(fkspec)
+    elif cuts:
         fktable_data = load_fktable(fkspec).with_cuts(cuts)
     else:
         fktable_data = load_fktable(fkspec)

--- a/validphys2/src/validphys/pineparser.py
+++ b/validphys2/src/validphys/pineparser.py
@@ -1,0 +1,218 @@
+"""
+    Loader for the pineappl-based FKTables
+
+    The FKTables for pineappl have ``pineappl.lz4`` and can be utilized
+    directly with the ``pineappl`` cli as well as read with ``pineappl.fk_table``
+"""
+
+import logging
+
+import numpy as np
+import pandas as pd
+
+from validphys.commondataparser import EXT
+from validphys.coredata import FKTableData
+
+log = logging.getLogger(__name__)
+
+
+def _pinelumi_to_columns(pine_luminosity, hadronic):
+    """Makes the pineappl luminosity into the column indices of a dataframe
+    These corresponds to the indices of a flattened (14x14) matrix for hadronic observables
+    and the non-zero indices of the 14-flavours for DIS
+
+    Parameters
+    ----------
+        pine_luminosity: list(tuple(int))
+            list with a pair of flavours per channel
+        hadronic: bool
+            flag for hadronic / DIS observables
+
+    Returns
+    -------
+        list(int): list of labels for the columns
+    """
+    evol_basis_pids = tuple(
+        [22, 100, 21, 200]
+        + [200 + n**2 - 1 for n in range(2, 6 + 1)]
+        + [100 + n**2 - 1 for n in range(2, 6 + 1)]
+    )
+    flav_size = len(evol_basis_pids)
+    columns = []
+    if hadronic:
+        for i, j in pine_luminosity:
+            idx = evol_basis_pids.index(i)
+            jdx = evol_basis_pids.index(j)
+            columns.append(flav_size * idx + jdx)
+    else:
+        # The proton might come from both sides
+        try:
+            columns = [evol_basis_pids.index(i) for _, i in pine_luminosity]
+        except ValueError:
+            columns = [evol_basis_pids.index(i) for i, _ in pine_luminosity]
+    return columns
+
+
+def pineappl_reader(fkspec):
+    """
+    Receives a fkspec, which contains the path to the fktables that are to be read by pineappl
+    as well as metadata that fixes things like conversion factors or apfelcomb flag.
+    The fkspec contains also the cfactors which are applied _directly_ to each of the fktables.
+
+    The output of this function is an instance of FKTableData which can be generated from reading
+    several FKTable files which get concatenated on the ndata (bin) axis.
+
+    For more information on the reading of pineappl tables:
+        https://pineappl.readthedocs.io/en/latest/modules/pineappl/pineappl.html#pineappl.pineappl.PyFkTable
+
+    About the reader:
+        Each pineappl table is a 4-dimensional grid with:
+            (ndata, active channels, x1, x2)
+        for DIS grids x2 will contain one single number.
+        The luminosity channels are given in a (flav1, flav2) format and thus need to be converted
+        to the 1-D index of a (14x14) luminosity tensor in order to put in the form of a dataframe.
+
+        All grids in pineappl are constructed with the exact same xgrid,
+        the active channels can vary and so when grids are concatenated for an observable
+        the gaps are filled with 0s.
+
+        The pineappl grids are such that obs = sum_{bins} fk * f (*f) * bin_w
+        so in order to use them together with old-style grids (obs = sum_{bins} fk * xf (*xf))
+        it is necessary to remove the factor of x and the normalization of the bins.
+
+    About apfelcomb flags in yamldb files:
+        old commondata files and old grids have over time been through various iterations while remaining compatibility between each other,
+        and fixes and hacks have been incorporated in one or another
+        for the new theory to be compatible with old commpondata it is necessary
+        to keep track of said hacks (and to apply conversion factors when required)
+    NOTE: both conversion factors and apfelcomb flags will be eventually removed.
+
+    Returns
+    -------
+        validphys.coredata.FKTableData
+            an FKTableData object containing all necessary information to compute predictions
+    """
+    from pineappl.fk_table import FkTable
+
+    pines = []
+    for fk_path in fkspec.fkpath:
+        try:
+            pines.append(FkTable.read(fk_path))
+        except BaseException as e:
+            # Catch absolutely any error coming from pineappl, give some info and immediately raise
+            log.error(f"Fatal error reading {fk_path}")
+            raise e
+
+    cfactors = fkspec.load_cfactors()
+
+    # Extract metadata from the first grid
+    pine_rep = pines[0]
+
+    # Is it hadronic? (at the moment only hadronic and DIS are considered)
+    hadronic = pine_rep.key_values()["initial_state_1"] == pine_rep.key_values()["initial_state_2"]
+    # Sanity check (in case at some point we start fitting things that are not protons)
+    if hadronic and pine_rep.key_values()["initial_state_1"] != "2212":
+        raise ValueError(
+            "pineappl_reader is not prepared to read a hadronic fktable with no protons!"
+        )
+    Q0 = np.sqrt(pine_rep.muf2())
+    xgrid = np.array([])
+    for pine in pines:
+        xgrid = np.union1d(xgrid, pine.x_grid())
+    xi = np.arange(len(xgrid))
+    protected = False
+
+    # Process the shifts and normalizations (if any),
+    # shifts is a dictionary with {fktable_name: shift_value}
+    # normalization instead {fktable_name: normalization to apply}
+    # since this parser doesn't know about operations, we need to convert it to a list
+    # then we just iterate over the fktables and apply the shift in the right order
+    shifts = fkspec.metadata.shifts
+    normalization_per_fktable = fkspec.metadata.normalization
+    fknames = [i.name.replace(f".{EXT}", "") for i in fkspec.fkpath]
+    if cfactors is not None:
+        cfactors = dict(zip(fknames, cfactors))
+
+    # fktables in pineapplgrid are for obs = fk * f while previous fktables were obs = fk * xf
+    # prepare the grid all tables will be divided by
+    if hadronic:
+        xdivision = np.prod(np.meshgrid(xgrid, xgrid), axis=0)
+    else:
+        xdivision = xgrid[:, np.newaxis]
+
+    partial_fktables = []
+    ndata = 0
+    for fkname, p in zip(fknames, pines):
+        # Start by reading possible cfactors if cfactor is not empty
+        cfprod = 1.0
+        if cfactors is not None:
+            for cfac in cfactors.get(fkname, []):
+                cfprod *= cfac.central_value
+
+        # Read the table, remove bin normalization and apply cfactors
+        raw_fktable = (cfprod * p.table().T / p.bin_normalizations()).T
+        n = raw_fktable.shape[0]
+
+        # Apply possible per-fktable fixes
+        if shifts is not None:
+            ndata += shifts.get(fkname, 0)
+
+        if normalization_per_fktable is not None:
+            raw_fktable = raw_fktable * normalization_per_fktable.get(fkname, 1.0)
+
+        # Add empty points to ensure that all fktables share the same x-grid upon convolution
+        missing_x_points = np.setdiff1d(xgrid, p.x_grid(), assume_unique=True)
+        for x_point in missing_x_points:
+            miss_index = list(xgrid).index(x_point)
+            raw_fktable = np.insert(raw_fktable, miss_index, 0.0, axis=2)
+            if hadronic:
+                raw_fktable = np.insert(raw_fktable, miss_index, 0.0, axis=3)
+        # Check conversion factors and remove the x* from the fktable
+        raw_fktable *= fkspec.metadata.conversion_factor / xdivision
+
+        # Create the multi-index for the dataframe
+        # for optimized pineappls different grids can potentially have different indices
+        # so they need to be indexed separately and then concatenated only at the end
+        lumi_columns = _pinelumi_to_columns(p.lumi(), hadronic)
+        lf = len(lumi_columns)
+        data_idx = np.arange(ndata, ndata + n)
+        if hadronic:
+            idx = pd.MultiIndex.from_product([data_idx, xi, xi], names=["data", "x1", "x2"])
+        else:
+            idx = pd.MultiIndex.from_product([data_idx, xi], names=["data", "x"])
+
+        # Now concatenate (data, x1, x2) and move the flavours to the columns
+        df_fktable = raw_fktable.swapaxes(0, 1).reshape(lf, -1).T
+        partial_fktables.append(pd.DataFrame(df_fktable, columns=lumi_columns, index=idx))
+
+        ndata += n
+
+    # Finallly concatenate all fktables, sort by flavours and fill any holes
+    sigma = pd.concat(partial_fktables, sort=True, copy=False).fillna(0.0)
+
+    # Check whether this is a 1-point normalization fktable and, if that's the case, protect!
+    if fkspec.metadata.operation == "RATIO" and len(pines) == 1:
+        # it _might_ be, check whether it is the divisor fktable
+        divisor = fkspec.metadata.FK_tables[-1][0]
+        name = fkspec.fkpath[0].name.replace(f".{EXT}", "")
+
+        if np.allclose(sigma.loc[1:], 0.0):
+            # Old denominator fktables were filled with 0s beyond the first point
+            # and they needed to be post-processed to repeat the same point many time
+            # Instead, drop everything beyond the 1st point (used 0:0 to keep the same kind of df)
+            sigma = sigma.loc[0:0]
+            ndata = 1
+
+        if ndata == 1:
+            # There's no doubt
+            protected = divisor == name
+
+    return FKTableData(
+        sigma=sigma,
+        ndata=ndata,
+        Q0=Q0,
+        metadata=fkspec.metadata,
+        hadronic=hadronic,
+        xgrid=xgrid,
+        protected=protected,
+    )


### PR DESCRIPTION
The scope of this PR is to allow SIMUnet to use new theories generated with pineappl.


TODO

- [ ] Run the new fk parser with theory 270
- [ ] Benchmark against previous fits done with theory 270
- [ ] Add `Loader` methods for checking new fktables (eg `check_fk_from_theory_metadata`, `_check_theory_old_or_new`)
- [ ] Possibly add a dataset name converter so that one can fully use theory 700 without having to just pick the new fktables and add them to theory 270