### PR TITLE
k-factor loading for plot_fancy of contaminated fits

### DIFF
--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -38,6 +38,7 @@ from validphys.core import (
     MatchedCuts,
     SimilarCuts,
     ThCovMatSpec,
+    PDF,
 )
 from validphys.fitdata import fitted_replica_indexes, num_fitted_replicas
 from validphys.loader import (
@@ -171,6 +172,10 @@ class CoreConfig(configparser.Config):
         except NotImplementedError as e:
             raise ConfigError(str(e))
         return pdf
+    
+    def parse_fakepdf(self, name: str) -> PDF:
+        """PDF set used to generate the fake data in a closure test."""
+        return self.parse_pdf(name)
 
     def parse_load_weights_from_fit(self, name: str):
         """A fit in the results folder, containing at least a valid filter result."""

--- a/validphys2/src/validphys/core.py
+++ b/validphys2/src/validphys/core.py
@@ -316,6 +316,18 @@ class CommonDataSpec(TupleComp):
         #TODO: Use better path handling in python 3.6
         return CommonData.ReadFile(str(self.datafile), str(self.sysfile))
 
+    def load_commondata(self, cuts=None):
+        """
+        Loads a coredata.CommonData object from a core.CommonDataSetSpec object
+        cuts are applied if provided.
+        """
+        # import here to avoid circular imports
+        from validphys.commondataparser import load_commondata
+        cd = load_commondata(self)
+        if cuts is not None:
+            cd = cd.with_cuts(cuts)
+        return cd
+
     @property
     def plot_kinlabels(self):
         return get_plot_kinlabels(self)

--- a/validphys2/src/validphys/coredata.py
+++ b/validphys2/src/validphys/coredata.py
@@ -263,6 +263,10 @@ class CommonData:
         add_table.columns = add_systype["name"].to_numpy()
         return add_table.loc[:, add_table.columns != "SKIP"]
 
+    @property
+    def cuts(self):
+        indices = self.commondata_table.index
+        return slice(indices[0]-1, indices[-1])
 
     def systematic_errors(self, central_values=None):
         """Returns all systematic errors as absolute uncertainties, with a

--- a/validphys2/src/validphys/dataplots.py
+++ b/validphys2/src/validphys/dataplots.py
@@ -199,7 +199,7 @@ def check_normalize_to(ns, **kwargs):
 #TODO: This interface is horrible. We need to think how to adapt libnnpdf
 #to make this use case easier
 def _plot_fancy_impl(results, commondata, cutlist,
-               normalize_to:(int,type(None)) = None, labellist=None):
+               normalize_to:(int,type(None)) = None, labellist=None): # type: ignore
 
     """Implementation of the data-theory comparison plots. Providers are
     supposed to call (yield from) this.
@@ -383,7 +383,7 @@ def _plot_fancy_impl(results, commondata, cutlist,
 @check_normalize_to
 @figuregen
 def plot_fancy(one_or_more_results, commondata, cuts,
-               normalize_to: (int, str, type(None)) = None):
+               normalize_to: (int, str, type(None)) = None): # type: ignore
     """
     Read the PLOTTING configuration for the dataset and generate the
     corrspondig data theory plot.
@@ -439,7 +439,7 @@ def plot_fancy_dataspecs(
     dataspecs_commondata,
     dataspecs_cuts,
     dataspecs_speclabel,
-    normalize_to: (str, int, type(None)) = None,
+    normalize_to: (str, int, type(None)) = None, # type: ignore
 ):
     """
     General interface for data-theory comparison plots.
@@ -1069,7 +1069,7 @@ def plot_xq2(
     display_cuts:bool=True,
     marker_by:str='process type',
     highlight_label:str='highlight',
-    highlight_datasets:(Sequence,type(None))=None,
+    highlight_datasets:(Sequence,type(None))=None, # type: ignore
     aspect:str='landscape',
 ):
     """Plot the (x,Q²) coverage based of the data based on some LO

--- a/validphys2/src/validphys/pseudodata.py
+++ b/validphys2/src/validphys/pseudodata.py
@@ -248,7 +248,7 @@ def level0_commondata_wc(data, fakepdf):
 
     data : validphys.core.DataGroupSpec
 
-    fakepdf: str
+    fakepdf: validphys.core.PDF
 
     Returns
     -------
@@ -269,7 +269,7 @@ def level0_commondata_wc(data, fakepdf):
 
     # argument fakepdf is passed as str
     # generate a core.PDF object with name equal to fakepdf argument
-    fakepdf = PDF(name=fakepdf)
+    # fakepdf = PDF(name=fakepdf)
 
     for dataset in data.datasets:
         commondata_wc = dataset.commondata.load_commondata()

--- a/validphys2/src/validphys/pseudodata.py
+++ b/validphys2/src/validphys/pseudodata.py
@@ -10,7 +10,9 @@ import hashlib
 import numpy as np
 import pandas as pd
 
-from validphys.covmats import INTRA_DATASET_SYS_NAME
+from validphys.covmats import INTRA_DATASET_SYS_NAME, dataset_t0_predictions
+
+from validphys.core import PDF
 
 from reportengine import collect
 
@@ -233,6 +235,154 @@ def indexed_make_replica(groups_index, make_replica):
     """
 
     return pd.DataFrame(make_replica, index=groups_index, columns=["data"])
+
+
+def level0_commondata_wc(data, fakepdf):
+    """
+    Given a validphys.core.DataGroupSpec object, load commondata and
+    generate a new commondata instance with central values replaced
+    by fakepdf prediction
+
+    Parameters
+    ----------
+
+    data : validphys.core.DataGroupSpec
+
+    fakepdf: str
+
+    Returns
+    -------
+    list
+        list of validphys.coredata.CommonData instances corresponding to
+        all datasets within one experiment. The central value is replaced
+        by Level 0 fake data.
+
+    Example
+    -------
+    >>> from validphys.api import API
+    >>> API.level0_commondata_wc(dataset_inputs=[{"dataset":"NMC"}], use_cuts="internal", theoryid=200, fakepdf="NNPDF40_nnlo_as_01180")
+
+    [CommonData(setname='NMC', ndata=204, commondataproc='DIS_NCE', nkin=3, nsys=16)]
+    """
+
+    level0_commondata_instances_wc = []
+
+    # argument fakepdf is passed as str
+    # generate a core.PDF object with name equal to fakepdf argument
+    fakepdf = PDF(name=fakepdf)
+
+    for dataset in data.datasets:
+        commondata_wc = dataset.commondata.load_commondata()
+        if dataset.cuts is not None:
+            cuts = dataset.cuts.load()
+            commondata_wc = commondata_wc.with_cuts(cuts)
+        # == Generate a new CommonData instance with central value given by Level 0 data generated with fakepdf ==#
+        t0_prediction = dataset_t0_predictions(
+            dataset=dataset, t0set=fakepdf
+        )  # N.B. cuts already applied to th. pred.
+        level0_commondata_instances_wc.append(commondata_wc.with_central_value(t0_prediction))
+
+    return level0_commondata_instances_wc
+
+
+def make_level1_data(
+        # data,
+        level0_commondata_wc,
+        filterseed,
+        data_index):
+    """
+    Given a list of Level 0 commondata instances, return the
+    same list with central values replaced by Level 1 data.
+
+    Level 1 data is generated using validphys.make_replica.
+    The covariance matrix, from which the stochastic Level 1
+    noise is sampled, is built from Level 0 commondata
+    instances (level0_commondata_wc). This, in particular,
+    means that the multiplicative systematics are generated
+    from the Level 0 central values.
+
+    Note that the covariance matrix used to generate Level 2
+    pseudodata is consistent with the one used at Level 1
+    up to corrections of the order eta * eps, where eta and
+    eps are defined as shown below:
+
+    Generate L1 data: L1 = L0 + eta, eta ~ N(0,CL0)
+    Generate L2 data: L2_k = L1 + eps_k, eps_k ~ N(0,CL1)
+
+    where CL0 and CL1 means that the multiplicative entries
+    have been constructed from Level 0 and Level 1 central
+    values respectively.
+
+
+    Parameters
+    ----------
+
+    REMOVE: data : validphys.core.DataGroupSpec
+
+    level0_commondata_wc : list
+                        list of validphys.coredata.CommonData instances corresponding to
+                        all datasets within one experiment. The central value is replaced
+                        by Level 0 fake data. Cuts already applied.
+
+    filterseed : int
+                random seed used for the generation of Level 1 data
+
+    data_index : pandas.MultiIndex
+
+    Returns
+    -------
+    list
+        list of validphys.coredata.CommonData instances corresponding to
+        all datasets within one experiment. The central value is replaced
+        by Level 1 fake data.
+
+    Example
+    -------
+
+    >>> from validphys.api import API
+    >>> dataset='NMC'
+    >>> l1_cd = API.make_level1_data(dataset_inputs = [{"dataset":dataset}],use_cuts="internal", theoryid=200,
+                             fakepdf = "NNPDF40_nnlo_as_01180", filterseed=1, data_index)
+    >>> l1_cd
+    [CommonData(setname='NMC', ndata=204, commondataproc='DIS_NCE', nkin=3, nsys=16)]
+    """
+
+    # from validphys.covmats import dataset_inputs_covmat_from_systematics
+
+    # dataset_input_list = list(data.dsinputs)
+
+    # covmat = dataset_inputs_covmat_from_systematics(
+    #     level0_commondata_wc,
+    #     dataset_input_list,
+    #     use_weights_in_covmat=False,
+    #     norm_threshold=None,
+    #     _list_of_central_values=None,
+    # )
+
+    # ================== generation of Level1 data ======================#
+    level1_data = make_replica(
+        level0_commondata_wc,
+        filterseed,
+        # covmat,
+        genrep=True
+    )
+
+    indexed_level1_data = indexed_make_replica(data_index, level1_data)
+
+    dataset_order = {cd.setname: i for i, cd in enumerate(level0_commondata_wc)}
+
+    # ===== create commondata instances with central values given by pseudo_data =====#
+    level1_commondata_dict = {c.setname: c for c in level0_commondata_wc}
+    level1_commondata_instances_wc = []
+
+    for xx, grp in indexed_level1_data.groupby('dataset'):
+        level1_commondata_instances_wc.append(
+            level1_commondata_dict[xx].with_central_value(grp.values)
+        )
+    # sort back so as to mantain same order as in level0_commondata_wc
+    level1_commondata_instances_wc.sort(key=lambda x: dataset_order[x.setname])
+
+    return level1_commondata_instances_wc
 
 
 _group_recreate_pseudodata = collect('indexed_make_replica', ('group_dataset_inputs_by_experiment',))

--- a/validphys2/src/validphys/pseudodata.py
+++ b/validphys2/src/validphys/pseudodata.py
@@ -608,7 +608,26 @@ def compute_chi2(
     return chi2_dict
 
 
-def write_chi2(pdf, compute_chi2, level0_commondata_wc):
+def write_chi2(
+        pdf,
+        compute_chi2,
+        level0_commondata_wc
+    ):
+
+    """
+    Parameters
+    ----------
+
+    pdf: core.PDF
+
+    compute_chi2
+
+    level0_commondata_wc
+
+    Returns
+    -------
+    
+    """
 
     ndata = {dataset.setname: [dataset.ndata] for dataset in level0_commondata_wc}
 
@@ -617,7 +636,7 @@ def write_chi2(pdf, compute_chi2, level0_commondata_wc):
 
     chi2 = pd.concat([df_ndat, df_chi2], ignore_index=True)
 
-    chi2.to_csv(f"{pdf}_chi2_dist.csv", index=False)
+    chi2.to_csv(f"output/tables/{pdf}_chi2_dist.csv", index=False)
 
 _group_recreate_pseudodata = collect('indexed_make_replica', ('group_dataset_inputs_by_experiment',))
 _recreate_fit_pseudodata = collect('_group_recreate_pseudodata', ('fitreplicas', 'fitenvironment'))

--- a/validphys2/src/validphys/pseudodata.py
+++ b/validphys2/src/validphys/pseudodata.py
@@ -636,7 +636,7 @@ def write_chi2(
 
     chi2 = pd.concat([df_ndat, df_chi2], ignore_index=True)
 
-    chi2.to_csv(f"output/tables/{pdf}_chi2_dist.csv", index=False)
+    chi2.to_csv(f"{pdf}_chi2_dist.csv", index=False)
 
 _group_recreate_pseudodata = collect('indexed_make_replica', ('group_dataset_inputs_by_experiment',))
 _recreate_fit_pseudodata = collect('_group_recreate_pseudodata', ('fitreplicas', 'fitenvironment'))

--- a/validphys2/src/validphys/results.py
+++ b/validphys2/src/validphys/results.py
@@ -37,6 +37,8 @@ from validphys.convolution import (
     predictions,
     PredictionsRequireCutsError,
 )
+from validphys.plotoptions.core import get_info
+
 
 from validphys.n3fit_data_utils import parse_simu_parameters_names_CF
 
@@ -167,6 +169,55 @@ groups_data = collect("data", ("group_dataset_inputs_by_metadata",))
 experiments_data = collect("data", ("group_dataset_inputs_by_experiment",))
 
 procs_data = collect("data", ("group_dataset_inputs_by_process",))
+
+
+def data_index(data):
+
+    """
+    Parameters
+    ----------
+
+    data: core.DataGroupSpec
+
+    Returns
+    -------
+
+    pandas.MultiIndex
+
+    Example
+    -------
+
+    >>> from validphys.loader import Loader
+    >>> from validphys.results import data_index
+    >>> l = Loader()
+    >>> dataset = l.check_dataset(name="NMC",
+                                  theoryid=200
+                                  )
+    >>> experiment = l.check_experiment(name="data",
+                                        datasets=[dataset]
+                                        )
+    >>> data_index(experiment)
+
+    MultiIndex([('NMC', 'NMC',  16),
+                ('NMC', 'NMC',  21),
+                ('NMC', 'NMC',  22),
+                ...
+                ('NMC', 'NMC', 289),
+                ('NMC', 'NMC', 290),
+                ('NMC', 'NMC', 291)],
+                names=['experiment', 'dataset', 'id'], length=204)
+
+    """
+
+    tuples = []
+
+    for dataset in data.datasets:
+        exp = get_info(dataset).experiment
+        for i in dataset.cuts.load():
+            tp = (exp, dataset.name, i)
+            tuples.append(tp)
+    
+    return pd.MultiIndex.from_tuples(tuples, names=('experiment', 'dataset', 'id'))
 
 
 def groups_index(groups_data):
@@ -541,7 +592,7 @@ def dataset_inputs_results(
 # ``results`` to support this.
 # TODO: The above comment doesn't make sense after adding T0. Deprecate this
 def pdf_results(
-    dataset: (DataSetSpec, DataGroupSpec),
+    dataset: (DataSetSpec, DataGroupSpec), # type: ignore
     pdfs: Sequence,
     covariance_matrix,
     sqrt_covmat,
@@ -557,12 +608,12 @@ def pdf_results(
 @require_one("pdfs", "pdf")
 @remove_outer("pdfs", "pdf")
 def one_or_more_results(
-    dataset: (DataSetSpec, DataGroupSpec),
+    dataset: (DataSetSpec, DataGroupSpec), # type: ignore
     covariance_matrix,
     sqrt_covmat,
     dataset_bsm_factor,
-    pdfs: (type(None), Sequence) = None,
-    pdf: (type(None), PDF) = None,
+    pdfs: (type(None), Sequence) = None, # type: ignore
+    pdf: (type(None), PDF) = None, # type: ignore
 ):
     """Generate a list of results, where the first element is the data values,
     and the next is either the prediction for pdf or for each of the pdfs.

--- a/validphys2/src/validphys/results.py
+++ b/validphys2/src/validphys/results.py
@@ -12,6 +12,8 @@ import logging
 import numpy as np
 import pandas as pd
 import scipy.linalg as la
+import os
+import yaml
 
 from NNPDF import CommonData
 from reportengine.checks import require_one, remove_outer, check_not_empty
@@ -38,13 +40,13 @@ from validphys.convolution import (
     PredictionsRequireCutsError,
 )
 from validphys.plotoptions.core import get_info
-
+from validphys.loader import Loader
 
 from validphys.n3fit_data_utils import parse_simu_parameters_names_CF
 
 
 log = logging.getLogger(__name__)
-
+l = Loader()
 
 class Result:
     pass
@@ -359,16 +361,16 @@ def group_result_table_68cl(
     return res
 
 
-def dataset_inputs_bsm_factor(data, pdf, read_bsm_facs):
+def dataset_inputs_bsm_factor(data, pdf, read_bsm_facs, contamination_parameters=None, theoryid=None):
     """Same as :py:func:`validphys.results.dataset_bsm_factor`
     but for a list of dataset inputs.
     """
     res =  np.concatenate(
-        [dataset_bsm_factor(dataset, pdf, read_bsm_facs) for dataset in data.datasets]
+        [dataset_bsm_factor(dataset, pdf, read_bsm_facs, contamination_parameters, theoryid) for dataset in data.datasets]
     )
     return res
 
-def dataset_bsm_factor(dataset, pdf, read_bsm_facs):
+def dataset_bsm_factor(dataset, pdf, read_bsm_facs, contamination_parameters=None, theoryid=None):
     """For each replica of ``pdf``, scale the fitted BSM-factors by
     the best fit value.
     Returns
@@ -382,12 +384,54 @@ def dataset_bsm_factor(dataset, pdf, read_bsm_facs):
                                                     dataset.cuts
                                                     )
 
-    if parsed_bsm_facs is None:
+    ndata = len(dataset.load().get_cv())
+    nrep = len(pdf)
+
+
+    if parsed_bsm_facs is None and dataset.contamination is None:
         # We want an array of ones that ndata x nrep
         # where ndata is the number of post cut datapoints
-        ndata = len(dataset.load().get_cv())
-        nrep = len(pdf)
         return np.ones((ndata, nrep))
+    
+
+    # after running a contamination fit we do not get fitted bsm factors in a csv
+    # hence, to produce a comparison between the data used for the fitting and the 
+    # theory prediction of such fit, we must load k-factors in another way
+    # we write the contamination name, value (e.g. zhat), and linear combination
+    # in the yaml file, and if the `contamination` keyword is present in the dataset_input
+    # we access the `SIMU_` file of the desired dataset, and load the k-factors
+    if dataset.contamination:
+
+        cont_order = dataset.contamination
+        bsm_path = l.datapath / f"theory_{theoryid.id}" / "simu_factors"
+       
+        if contamination_parameters is None:
+            log.warning("No Contamination parameters provided")
+            return np.ones((ndata, nrep))
+        
+        else:
+            bsm_file = bsm_path / f"SIMU_{dataset.name}.yaml"
+            if not os.path.exists(bsm_file):
+                log.error(f"Could not find a BSM-factor for {dataset.name}. Are you sure they exist in the given theory?")
+                return np.ones((ndata, nrep))
+            
+            log.info(f"Loading {dataset.name}")
+
+            cont_name = contamination_parameters["name"]
+            cont_value = contamination_parameters["value"]
+            cont_lin_comb = contamination_parameters["linear_combination"]
+
+            with open(bsm_file, "r+") as stream:
+                simu_card = yaml.safe_load(stream)
+            stream.close()
+
+            k_factors = np.zeros(len(simu_card["SM_fixed"]))
+            for op in cont_lin_comb:
+                k_factors += cont_lin_comb[op] * np.array(simu_card[cont_order][op])
+            k_factors = 1. + k_factors * cont_value / np.array(simu_card[cont_order]["SM"])
+
+            cuts = dataset.cuts.load()
+            return np.array([k_factors[cuts]] * nrep).T
 
     fit_bsm_fac_df = pd.DataFrame(
         {k: v.central_value for k, v in parsed_bsm_facs.items()}


### PR DESCRIPTION
in `validphys.results` in `dataset_bsm_factosr` added the k-factors loading when the `contamination` keyword is present in the the `dataset_inputs` elements, the logic of the function is still the same, when the `contamination` keyword is not present, the previous behaviour is mantained