### PR TITLE
added fixed_bsm

### DIFF
--- a/n3fit/src/n3fit/model_trainer.py
+++ b/n3fit/src/n3fit/model_trainer.py
@@ -125,6 +125,7 @@ class ModelTrainer:
         simu_parameters_scales=None,
         bsm_fac_initialisations=None,
         bsm_initialisation_seed=0,
+        fixed_bsm=False,
         debug=False,
         kfold_parameters=None,
         max_cores=None,
@@ -188,6 +189,7 @@ class ModelTrainer:
         self.simu_parameters_scales = simu_parameters_scales
         self.bsm_fac_initialisations = bsm_fac_initialisations
         self.bsm_initialisation_seed = bsm_initialisation_seed
+        self.fixed_bsm = fixed_bsm
         self.fixed_pdf = fixed_pdf
         self.replicas = replicas
 
@@ -514,6 +516,9 @@ class ModelTrainer:
             initialisation_seed=self.bsm_initialisation_seed,
             replica_number=self.replicas[0],
         )
+
+        if self.fixed_bsm:
+            combiner.trainable = False
 
         log.info(f"Using bsm_factor scales: {self.simu_parameters_scales}")
         self.combiner = combiner

--- a/n3fit/src/n3fit/performfit.py
+++ b/n3fit/src/n3fit/performfit.py
@@ -44,6 +44,7 @@ def performfit(
     parallel_models=False, 
     simu_parameters_names=None,
     bsm_initialisation_seed=0,
+    fixed_bsm=False,
 ):
     """
         This action will (upon having read a validcard) process a full PDF fit
@@ -208,6 +209,7 @@ def performfit(
             simu_parameters_scales=simu_parameters_scales,
             bsm_fac_initialisations=bsm_fac_initialisations,
             bsm_initialisation_seed=bsm_initialisation_seed,
+            fixed_bsm=fixed_bsm,
         )
 
         # This is just to give a descriptive name to the fit function


### PR DESCRIPTION
The aim of the PR is being able to perform PDF fits with a fixed BSM Wilson coefficient or Wilson coefficients linear combinations, using the simultaneous fit framework setting the `simu_parameters` to a fixed value using the `constant` keyword initialisation and adding `fixed_bsm: True` to the `n3fit` runcard.

- Added `fixed_bsm` parameter to `performfit` function in `n3fit/src/n3fit/performfit.py`
- Added `fixed_bsm` parameter to `ModelTrainer` object initialisation in `n3fit/src/n3fit/performfit.py`
- Set `CombineCfacLayer` object to have untrainable weights if `fixed_bsm` is `True` in `_generate_observables` method of `ModelTrainer` class in `n3fit/src/n3fit/model_trainer.py`

I will add an example runcard once I test everything works properly