### PR TITLE
Update `reportengine.compat` to `ruamel.yaml`

### DIFF
--- a/n3fit/src/n3fit/io/writer.py
+++ b/n3fit/src/n3fit/io/writer.py
@@ -7,7 +7,7 @@
 import os
 import json
 import numpy as np
-from reportengine.compat import yaml
+from validphys.utils import yaml_safe
 import validphys
 import n3fit
 from n3fit import vpinterface
@@ -272,4 +272,4 @@ def storefit(
     }
 
     with open(f"{replica_path}/{fitname}.exportgrid", "w") as fs:
-        yaml.dump(data, fs)
+        yaml_safe.dump(data, fs)

--- a/n3fit/src/n3fit/scripts/n3fit_exec.py
+++ b/n3fit/src/n3fit/scripts/n3fit_exec.py
@@ -15,8 +15,9 @@ from validphys.app import App
 from validphys.config import Environment, Config
 from validphys.config import EnvironmentError_, ConfigError
 from validphys.core import FitSpec
+from validphys.utils import yaml_safe
 from reportengine import colors
-from reportengine.compat import yaml
+from ruamel.yaml.error import YAMLError, MantissaNoDotYAML1_1Warning
 from reportengine.namespaces import NSList
 
 
@@ -114,14 +115,14 @@ class N3FitConfig(Config):
     def from_yaml(cls, o, *args, **kwargs):
         try:
             with warnings.catch_warnings():
-                warnings.simplefilter("ignore", yaml.error.MantissaNoDotYAML1_1Warning)
+                warnings.simplefilter("ignore", MantissaNoDotYAML1_1Warning)
                 # We need to specify the older version 1.1 to support the
                 # older configuration files, which liked to use on/off for
                 # booleans.
                 # The floating point parsing yields warnings everywhere, which
                 # we suppress.
-                file_content = yaml.safe_load(o, version="1.1")
-        except yaml.error.YAMLError as e:
+                file_content = yaml_safe.load(o, version="1.1")
+        except YAMLError as e:
             raise ConfigError(f"Failed to parse yaml file: {e}")
         if not isinstance(file_content, dict):
             raise ConfigError(f"Expecting input runcard to be a mapping, " f"not '{type(file_content)}'.")

--- a/n3fit/src/n3fit/scripts/vp_setupfit.py
+++ b/n3fit/src/n3fit/scripts/vp_setupfit.py
@@ -35,7 +35,8 @@ import warnings
 
 from validphys.config import Environment, Config, EnvironmentError_, ConfigError
 from validphys.app import App
-from reportengine.compat import yaml
+from validphys.utils import yaml_safe
+from ruamel.yaml.error import YAMLError, MantissaNoDotYAML1_1Warning
 from reportengine import colors
 
 
@@ -134,14 +135,14 @@ class SetupFitConfig(Config):
         try:
             with warnings.catch_warnings():
                 warnings.simplefilter('ignore',
-                                      yaml.error.MantissaNoDotYAML1_1Warning)
+                                      MantissaNoDotYAML1_1Warning)
                 #We need to specify the older version 1.1 to support the
                 #older configuration files, which liked to use on/off for
                 #booleans.
                 #The floating point parsing yields warnings everywhere, which
                 #we suppress.
-                file_content = yaml.safe_load(o, version='1.1')
-        except yaml.error.YAMLError as e:
+                file_content = yaml_safe.load(o, version='1.1')
+        except YAMLError as e:
             raise ConfigError(f"Failed to parse yaml file: {e}")
         if not isinstance(file_content, dict):
             raise ConfigError(f"Expecting input runcard to be a mapping, "

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -28,7 +28,7 @@ from reportengine.configparser import (
 from reportengine.helputils import get_parser_type
 from reportengine.namespaces import NSList
 from reportengine import report
-from reportengine.compat import yaml
+from validphys.utils import yaml_safe
 
 from validphys.core import (
     DataGroupSpec,
@@ -1323,7 +1323,7 @@ class CoreConfig(configparser.Config):
 
         lock_token = "_filters.lock.yaml"
         try:
-            return yaml.safe_load(
+            return yaml_safe.load(
                 read_text(validphys.cuts.lockfiles, f"{spec}{lock_token}")
             )
         except FileNotFoundError as e:
@@ -1404,7 +1404,7 @@ class CoreConfig(configparser.Config):
 
         lock_token = "_defaults.lock.yaml"
         try:
-            return yaml.safe_load(
+            return yaml_safe.load(
                 read_text(validphys.cuts.lockfiles, f"{spec}{lock_token}")
             )
         except FileNotFoundError as e:
@@ -1701,7 +1701,7 @@ class CoreConfig(configparser.Config):
         pp = point_prescription
         th = theoryid.id
 
-        lsv = yaml.safe_load(
+        lsv = yaml_safe.load(
             read_text(validphys.scalevariations, "scalevariationtheoryids.yaml")
         )
 
@@ -1720,7 +1720,7 @@ class CoreConfig(configparser.Config):
             )
 
         # Find scales that correspond to this point prescription
-        pp_scales_dict = yaml.safe_load(
+        pp_scales_dict = yaml_safe.load(
             read_text(validphys.scalevariations, "pointprescriptions.yaml")
         )
 

--- a/validphys2/src/validphys/core.py
+++ b/validphys2/src/validphys/core.py
@@ -23,7 +23,8 @@ import numpy as np
 
 from reportengine import namespaces
 from reportengine.baseexceptions import AsInputError
-from reportengine.compat import yaml
+from validphys.utils import yaml_safe
+from ruamel.yaml import YAMLError
 
 from NNPDF import (LHAPDFSet as libNNPDF_LHAPDFSet,
     CommonData,
@@ -525,7 +526,7 @@ class DataSetSpec(TupleComp):
             # pseudodata with.
             simu_fac_path = str(self.fkspecs[0].fkpath).split('fastkernel')[0] + "simu_factors/SIMU_" + cd.GetSetName() + ".yaml"
             with open(simu_fac_path, 'rb') as file:
-                simu_file = yaml.safe_load(file)
+                simu_file = yaml_safe.load(file)
             contamination_values = np.array([0.0]*cd.GetNData())
             if self.contamination_data:
                 for parameter in self.contamination_data:
@@ -689,8 +690,8 @@ class FitSpec(TupleComp):
         log.debug('Reading input from fit configuration %s' , p)
         try:
             with p.open() as f:
-                d = yaml.safe_load(f)
-        except (yaml.YAMLError, FileNotFoundError) as e:
+                d = yaml_safe.load(f)
+        except (YAMLError, FileNotFoundError) as e:
             raise AsInputError(str(e)) from e
         d['pdf'] = {'id': self.name, 'label': self.label}
 

--- a/validphys2/src/validphys/eff_exponents.py
+++ b/validphys2/src/validphys/eff_exponents.py
@@ -14,7 +14,7 @@ import numpy as np
 import pandas as pd
 
 from reportengine import collect
-from reportengine.compat import yaml
+from validphys.utils import yaml_rt
 from reportengine.figure import figuregen
 from reportengine.floatformatting import format_number, significant_digits
 from reportengine.table import table
@@ -464,7 +464,7 @@ def iterate_preprocessing_yaml(
     (df_effexps,) = next_fit_eff_exps_table
     # Use round trip loader rather than safe_load in fit.as_input()
     with open(fit.path / "filter.yml", "r") as f:
-        filtermap = yaml.load(f, yaml.RoundTripLoader)
+        filtermap = yaml_rt.load(f,)
     previous_exponents = filtermap["fitting"]["basis"]
     basis = filtermap["fitting"]["fitbasis"]
     checked = check_basis(basis, None)
@@ -490,7 +490,7 @@ def iterate_preprocessing_yaml(
         previous_exponents[i]["largex"] = [
             fmt(beta) for beta in betas
         ]
-    return yaml.dump(filtermap, Dumper=yaml.RoundTripDumper)
+    return yaml_rt.dump(filtermap,)
 
 
 def update_runcard_description_yaml(
@@ -506,13 +506,13 @@ def update_runcard_description_yaml(
     ```
 
     """
-    filtermap = yaml.load(iterate_preprocessing_yaml, yaml.RoundTripLoader)
+    filtermap = yaml_rt.load(iterate_preprocessing_yaml,)
 
     # update description if necessary
     if _updated_description is not None:
         filtermap["description"] = _updated_description
 
-    return yaml.dump(filtermap, Dumper=yaml.RoundTripDumper)
+    return yaml_rt.dump(filtermap,)
 
 
 def iterated_runcard_yaml(
@@ -546,7 +546,7 @@ def iterated_runcard_yaml(
     ...     f.write(yaml_output)
 
     """
-    filtermap = yaml.load(update_runcard_description_yaml, yaml.RoundTripLoader)
+    filtermap = yaml_rt.load(update_runcard_description_yaml,)
     # iterate t0
     filtermap["datacuts"]["t0pdfset"] = fit.name
 
@@ -570,4 +570,4 @@ def iterated_runcard_yaml(
         if "filterseed" in closuretest_data:
             closuretest_data["filterseed"] = random.randrange(0, maxint)
 
-    return yaml.dump(filtermap, Dumper=yaml.RoundTripDumper)
+    return yaml_rt.dump(filtermap,)

--- a/validphys2/src/validphys/filters.py
+++ b/validphys2/src/validphys/filters.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from NNPDF import CommonData
 from reportengine.checks import make_argcheck, check, check_positive, make_check
-from reportengine.compat import yaml
+from validphys.utils import yaml_safe
 import validphys.cuts
 
 log = logging.getLogger(__name__)
@@ -36,14 +36,14 @@ def default_filter_settings_input():
     """Return a dictionary with the default hardcoded filter settings.
     These are defined in ``defaults.yaml`` in the ``validphys.cuts`` module.
     """
-    return yaml.safe_load(read_text(validphys.cuts, "defaults.yaml"))
+    return yaml_safe.load(read_text(validphys.cuts, "defaults.yaml"))
 
 
 def default_filter_rules_input():
     """Return a dictionary with the input settings.
     These are defined in ``filters.yaml`` in the ``validphys.cuts`` module.
     """
-    return yaml.safe_load(read_text(validphys.cuts, "filters.yaml"))
+    return yaml_safe.load(read_text(validphys.cuts, "filters.yaml"))
 
 
 @make_argcheck

--- a/validphys2/src/validphys/fitdata.py
+++ b/validphys2/src/validphys/fitdata.py
@@ -10,7 +10,7 @@ import pathlib
 
 import numpy as np
 import pandas as pd
-from reportengine.compat import yaml
+from validphys.utils import yaml_safe
 
 from reportengine import collect
 from reportengine.table import table
@@ -377,7 +377,7 @@ def _get_fitted_index(pdf, i):
     """Return the nnfit index for the replica i"""
     p = pdf.infopath.with_name(f'{pdf.name}_{i:04d}.dat')
     with open(p) as f:
-        it = yaml.safe_load_all(f)
+        it = yaml_safe.load_all(f)
         metadata = next(it)
     return metadata['FromMCReplica']
 

--- a/validphys2/src/validphys/lhaindex.py
+++ b/validphys2/src/validphys/lhaindex.py
@@ -12,7 +12,7 @@ import glob
 import fnmatch
 from functools import lru_cache
 
-from reportengine.compat import yaml
+from validphys.utils import yaml_safe
 import lhapdf
 
 
@@ -112,7 +112,7 @@ def infofilename(name):
 @lru_cache()
 def parse_info(name):
     with open(infofilename(name)) as infofile:
-        result = yaml.safe_load(infofile)
+        result = yaml_safe.load(infofile)
     return result
 
 def get_lha_paths():

--- a/validphys2/src/validphys/lhio.py
+++ b/validphys2/src/validphys/lhio.py
@@ -12,7 +12,7 @@ import lhapdf
 import numpy as np
 import pandas as pd
 
-from reportengine.compat import yaml
+from validphys.utils import yaml_safe
 from validphys import lhaindex
 from validphys.core import PDF
 
@@ -315,7 +315,7 @@ def hessian_from_lincomb(pdf, V, set_name=None, folder = None, extra_fields=None
             else:
                 out.write(l)
         if extra_fields is not None:
-            yaml.dump(extra_fields, out, default_flow_style=False)
+            yaml_safe.dump(extra_fields, out, default_flow_style=False)
 
     _headers, grids = load_all_replicas(pdf)
     result  = (big_matrix(grids).dot(V)).add(grids[0], axis=0, )

--- a/validphys2/src/validphys/loader.py
+++ b/validphys2/src/validphys/loader.py
@@ -23,14 +23,14 @@ from functools import cached_property
 from typing import List
 
 import requests
-from reportengine.compat import yaml
+from ruamel.yaml import YAMLError
 from reportengine import filefinder
 
 from validphys.core import (CommonDataSpec, FitSpec, TheoryIDSpec, FKTableSpec,
                             PositivitySetSpec, DataSetSpec, PDF, Cuts, DataGroupSpec,
                             peek_commondata_metadata, CutsPolicy,
                             InternalCutsWrapper, HyperscanSpec)
-from validphys.utils import tempfile_cleaner
+from validphys.utils import tempfile_cleaner, yaml_safe
 from validphys import lhaindex
 
 DEFAULT_NNPDF_PROFILE_PATH = f"{sys.prefix}/share/NNPDF/nnprofile.yaml"
@@ -94,8 +94,8 @@ def _get_nnpdf_profile(profile_path=None):
     mpath = pathlib.Path(profile_path)
     try:
         with mpath.open() as f:
-            profile_dict = yaml.safe_load(f)
-    except (OSError, yaml.YAMLError) as e:
+            profile_dict = yaml_safe.load(f)
+    except (OSError, YAMLError) as e:
         raise LoaderError(f"Could not parse profile file {mpath}: {e}") from e
     return profile_dict
 
@@ -385,7 +385,7 @@ class Loader(LoaderBase):
             raise CompoundNotFound(msg)
         #This is a little bit funny, but is the least amount of thinking...
         yaml_format = 'FK:\n' + re.sub('FK:', ' - ', txt)
-        data = yaml.safe_load(yaml_format)
+        data = yaml_safe.load(yaml_format)
         #we have to split out 'FK_' the extension to get a name consistent
         #with everything else
         try:
@@ -516,7 +516,7 @@ class Loader(LoaderBase):
         
         # test whether all the mandatory keys are present
         with open(simufactorpath, 'rb') as stream:
-            cfac_file = yaml.safe_load(stream)
+            cfac_file = yaml_safe.load(stream)
         
         if "metadata" not in cfac_file:
                 raise KeyError(f"The 'metadata' key is not present in the SIMU file at {simufactorpath}.")

--- a/validphys2/src/validphys/plotoptions/core.py
+++ b/validphys2/src/validphys/plotoptions/core.py
@@ -16,7 +16,8 @@ import numbers
 from validobj import ValidationError
 
 from reportengine.floatformatting import format_number
-from reportengine.compat import yaml
+# from reportengine.compat import yaml
+from validphys.utils import yaml_rt
 from reportengine.utils import get_functions, ChainMap
 
 from NNPDF import CommonData, DataSet
@@ -160,7 +161,7 @@ class PlotInfo:
         if commondata.plotfiles:
             for file in commondata.plotfiles:
                 with open(file) as f:
-                    processed_input = yaml.round_trip_load(f)
+                    processed_input = yaml_rt.load(f)
                     pf = parse_yaml_inp(processed_input, PlottingFile, file)
                     config_params = dataclasses.asdict(pf, dict_factory=dict_factory)
                 plot_params = plot_params.new_child(config_params)

--- a/validphys2/src/validphys/replica_selector.py
+++ b/validphys2/src/validphys/replica_selector.py
@@ -13,7 +13,6 @@ import numpy as np
 import pandas as pd
 
 from reportengine.checks import check_positive, make_argcheck, check
-from reportengine.compat import yaml
 from reportengine.table import table
 from reportengine.figure import figuregen
 
@@ -24,7 +23,7 @@ from validphys.checks import check_pdf_is_montecarlo, check_scale
 from validphys.core import PDF
 from validphys.pdfplots import ReplicaPDFPlotter
 from validphys.renametools import rename_pdf
-from validphys.utils import tempfile_cleaner
+from validphys.utils import tempfile_cleaner, yaml_safe
 
 log = logging.getLogger(__name__)
 
@@ -107,8 +106,7 @@ def alpha_s_bundle_pdf(pdf, pdfs, output_path, target_name: (str, type(None)) = 
         info_file = (temp_pdf / temp_pdf.name).with_suffix('.info')
 
         with open(info_file, 'r') as stream:
-            yaml_obj = yaml.YAML()
-            info_yaml = yaml_obj.load(stream)
+            info_yaml = yaml_safe.load(stream)
         info_yaml['NumMembers'] = new_nrep
         info_yaml['error_type'] += '+as'
         extra_desc = '; '.join(
@@ -117,7 +115,7 @@ def alpha_s_bundle_pdf(pdf, pdfs, output_path, target_name: (str, type(None)) = 
         )
         info_yaml['SetDesc'] += f"; {extra_desc}"
         with open(info_file, 'w') as stream:
-            yaml_obj.dump(info_yaml, stream)
+            yaml_safe.dump(info_yaml, stream)
 
         # Rename the base pdf to the final name
         rename_pdf(temp_pdf, pdf.name, target_name)

--- a/validphys2/src/validphys/scripts/vp_comparefits.py
+++ b/validphys2/src/validphys/scripts/vp_comparefits.py
@@ -6,7 +6,7 @@ import logging
 import prompt_toolkit
 from prompt_toolkit.completion import WordCompleter
 
-from reportengine.compat import yaml
+from validphys.utils import yaml_safe
 from reportengine.colors import t
 
 from validphys.app import App
@@ -298,7 +298,7 @@ class CompareFitApp(App):
         with open(self.args['config_yml']) as f:
             #TODO: Ideally this would load round trip but needs
             #to be fixed in reportengine.
-            c = yaml.safe_load(f)
+            c = yaml_safe.load(f)
         c.update(self.complete_mapping())
         return self.config_class(c, environment=self.environment)
 

--- a/validphys2/src/validphys/scripts/vp_deltachi2.py
+++ b/validphys2/src/validphys/scripts/vp_deltachi2.py
@@ -2,7 +2,7 @@ import logging
 import os
 import pwd
 
-from reportengine.compat import yaml
+from validphys.utils import yaml_safe
 
 from validphys import deltachi2templates
 from validphys.app import App
@@ -85,7 +85,7 @@ class HyperoptPlotApp(App):
         with open(runcard) as f:
             # TODO: Ideally this would load round trip but needs
             # to be fixed in reportengine.
-            c = yaml.safe_load(f)
+            c = yaml_safe.load(f)
         c.update(complete_mapping)
         return self.config_class(c, environment=self.environment)
 

--- a/validphys2/src/validphys/scripts/vp_fakeevolve.py
+++ b/validphys2/src/validphys/scripts/vp_fakeevolve.py
@@ -16,7 +16,7 @@ import prompt_toolkit
 import shutil
 
 from reportengine import colors
-from reportengine.compat import yaml
+from validphys.utils import yaml_safe
 
 from validphys.api import API
 
@@ -40,7 +40,7 @@ def main():
     input_dir = pathlib.Path(input_fit)
 
     with open(input_dir / "filter.yml", 'r') as file:
-        input_info = yaml.safe_load(file)
+        input_info = yaml_safe.load(file)
 
     fixed_fit = input_info['load_weights_from_fit']
     l = Loader()

--- a/validphys2/src/validphys/scripts/vp_hyperoptplot.py
+++ b/validphys2/src/validphys/scripts/vp_hyperoptplot.py
@@ -1,7 +1,7 @@
 from validphys.app import App
 from validphys.loader import Loader, HyperscanNotFound
 from validphys import hyperplottemplates
-from reportengine.compat import yaml
+from validphys.utils import yaml_safe
 import pwd
 import os
 
@@ -104,7 +104,7 @@ class HyperoptPlotApp(App):
             hyperop_folder = hyperop_folder[:-1]
 
         with open(hyperopt_filter) as f:
-            filtercard = yaml.safe_load(f)
+            filtercard = yaml_safe.load(f)
 
         folder_path = hyperop_folder
         index_slash = folder_path.rfind("/") + 1
@@ -148,7 +148,7 @@ class HyperoptPlotApp(App):
         with open(self.args['config_yml']) as f:
             # TODO: Ideally this would load round trip but needs
             # to be fixed in reportengine.
-            c = yaml.safe_load(f)
+            c = yaml_safe.load(f)
         c.update(self.complete_mapping())
         return self.config_class(c, environment=self.environment)
 

--- a/validphys2/src/validphys/scripts/vp_nextfitruncard.py
+++ b/validphys2/src/validphys/scripts/vp_nextfitruncard.py
@@ -23,7 +23,7 @@ import logging
 import prompt_toolkit
 
 from reportengine import colors
-from reportengine.compat import yaml
+from validphys.utils import yaml_safe
 
 from validphys.api import API
 
@@ -125,7 +125,7 @@ def main():
         preproc_lims = PREPROCESSING_LIMS
         log.info(
             "The following constraints will be used for preprocessing ranges, \n%s",
-            yaml.dump(preproc_lims),
+            yaml_safe.dump(preproc_lims),
         )
     else:
         # don't enforce any limits.

--- a/validphys2/src/validphys/scripts/vp_pdffromreplicas.py
+++ b/validphys2/src/validphys/scripts/vp_pdffromreplicas.py
@@ -30,7 +30,7 @@ import tempfile
 
 import pandas as pd
 from reportengine import colors
-from reportengine.compat import yaml
+from validphys.utils import yaml_safe
 
 from validphys import lhaindex
 from validphys.lhio import new_pdf_from_indexes
@@ -144,11 +144,11 @@ def main():
         )
         # fixup info file
         with open(base_name + ".info", "r") as f:
-            info_file = yaml.safe_load(f)
+            info_file = yaml_safe.load(f)
 
         info_file["NumMembers"] = 3
         with open(base_name + ".info", "w") as f:
-            yaml.dump(info_file, f)
+            yaml_safe.dump(info_file, f)
 
         # here we update old indices in case the user creates
         # the original_index_mapping.csv

--- a/validphys2/src/validphys/scripts/vp_pdfrename.py
+++ b/validphys2/src/validphys/scripts/vp_pdfrename.py
@@ -21,7 +21,7 @@ import tempfile
 import lhapdf
 
 from reportengine import colors
-from reportengine.compat import yaml
+from ruamel.yaml import YAML
 
 from validphys.renametools import rename_pdf
 
@@ -81,7 +81,7 @@ def fixup_ref(pdf_path: pathlib.Path, field_dict):
     infopath = pdf_path / f"{pdf_name}.info"
 
     with open(infopath) as f:
-        y = yaml.YAML()
+        y = YAML()
         res = y.load(f)
 
     # If a field entry is not provided, then we revert to the existing

--- a/validphys2/src/validphys/scripts/wiki_upload.py
+++ b/validphys2/src/validphys/scripts/wiki_upload.py
@@ -50,7 +50,7 @@ def edit_settings(d):
 
 def handle_meta_interactive(output):
     metapath = output / 'meta.yaml'
-    from reportengine.compat import yaml
+    from validphys.utils import yaml_rt
     #The yaml lexer is broken. Use something else.
     lex = pygments.lexers.get_lexer_by_name('pkgconfig')
     fmt = pygments.formatters.TerminalFormatter()
@@ -66,7 +66,7 @@ def handle_meta_interactive(output):
         edit = not confirm(msg, default=True)
 
         if edit:
-            d = yaml.load(content, yaml.RoundTripLoader)
+            d = yaml_rt.load(content)
         else:
             return
 
@@ -82,7 +82,7 @@ def handle_meta_interactive(output):
         print("Metadata:")
 
         s = io.StringIO()
-        yaml.dump(d, s, yaml.RoundTripDumper)
+        yaml_rt.dump(d, s)
         metastr = s.getvalue()
         print(pygments.highlight(metastr, lex, fmt))
 

--- a/validphys2/src/validphys/tests/test_effexponents.py
+++ b/validphys2/src/validphys/tests/test_effexponents.py
@@ -1,7 +1,6 @@
 import pytest
 
-from reportengine.compat import yaml
-
+from validphys.utils import yaml_safe
 from validphys.api import API
 from validphys.loader import FallbackLoader as Loader
 from validphys.scripts.vp_nextfitruncard import PREPROCESSING_LIMS
@@ -26,9 +25,9 @@ def test_next_runcard():
     # to load various keys that are not present in the actual runcard for
     # backwards compatibility
     with open(l.check_fit(FIT_ITERATED).path / "filter.yml", "r") as f:
-        ite2_runcard = yaml.safe_load(f)
+        ite2_runcard = yaml_safe.load(f)
 
-    predicted_ite2_runcard = yaml.safe_load(
+    predicted_ite2_runcard = yaml_safe.load(
         API.iterated_runcard_yaml(fit=FIT, _flmap_np_clip_arg=PREPROCESSING_LIMS)
     )
 

--- a/validphys2/src/validphys/tests/test_postfit.py
+++ b/validphys2/src/validphys/tests/test_postfit.py
@@ -10,7 +10,7 @@ import shutil
 
 from validphys.loader import FallbackLoader as Loader
 from validphys.tests.conftest import FIT
-from reportengine.compat import yaml
+from validphys.utils import yaml_safe
 
 
 def test_postfit(tmp):
@@ -80,7 +80,7 @@ def test_postfit(tmp):
         ]
         for file in files:
             with open(file, "r") as f:
-                data = yaml.safe_load_all(f)
+                data = yaml_safe.load_all(f)
                 metadata = next(data)
                 repnos.add(metadata["FromMCReplica"])
         assert (
@@ -91,7 +91,7 @@ def test_postfit(tmp):
     # Check that number of PDF members is written correctly
     infopath = postfitpath / f"{TMPFIT}/{TMPFIT}.info"
     with open(infopath, "r") as f:
-        data = yaml.safe_load(f)
+        data = yaml_safe.load(f)
         # Add one to nrep to account for replica 0
         assert (
             data["NumMembers"] == nrep + 1

--- a/validphys2/src/validphys/uploadutils.py
+++ b/validphys2/src/validphys/uploadutils.py
@@ -22,7 +22,7 @@ import hashlib
 import prompt_toolkit
 from prompt_toolkit.completion import WordCompleter
 
-from reportengine.compat import yaml
+from validphys.utils import yaml_safe
 from reportengine.colors import t
 from validphys.loader import RemoteLoader, Loader
 from validphys.renametools import Spinner
@@ -370,7 +370,7 @@ def interactive_meta(path):
 
     meta_dict = {"title": title, "author": author, "keywords": keywords}
     with open(path / "meta.yaml", "w") as stream:
-        yaml.safe_dump(meta_dict, stream)
+        yaml_safe.dump(meta_dict, stream)
 
 
 def check_input(path):

--- a/validphys2/src/validphys/utils.py
+++ b/validphys2/src/validphys/utils.py
@@ -13,6 +13,11 @@ import numpy as np
 
 from validobj import parse_input, ValidationError
 
+from ruamel.yaml import YAML
+
+yaml_safe = YAML(typ="safe")
+yaml_rt = YAML(typ="rt")
+
 
 def parse_yaml_inp(inp, spec, path):
     """Helper function to parse yaml using the `validobj` library and print


### PR DESCRIPTION
As it is done in https://github.com/NNPDF/nnpdf/blob/master/validphys2/src/validphys/utils.py, added the `yaml_safe` and `yaml_rt` objets and replaced them in the `n3fit` and `validphys` modules.