### PR TITLE
Removed 'version' from YAML.load()

### DIFF
--- a/n3fit/src/n3fit/scripts/vp_setupfit.py
+++ b/n3fit/src/n3fit/scripts/vp_setupfit.py
@@ -141,7 +141,7 @@ class SetupFitConfig(Config):
                 #booleans.
                 #The floating point parsing yields warnings everywhere, which
                 #we suppress.
-                file_content = yaml_safe.load(o, version='1.1')
+                file_content = yaml_safe.load(o)
         except YAMLError as e:
             raise ConfigError(f"Failed to parse yaml file: {e}")
         if not isinstance(file_content, dict):


### PR DESCRIPTION
`file_content = yaml.safe_load(o, version='1.1') ` ---> `file_content = yaml.safe_load(o)`

Fixes a bug:
```
[CRITICAL]: Bug in setup-fit ocurred. Please report it.
Traceback (most recent call last):
  File "/rds/user/egc41/hpc-work/codes/simunet_git/SIMUnet/n3fit/src/n3fit/scripts/vp_setupfit.py", line 199, in run
    super().run()
  File "/rds/user/egc41/hpc-work/codes/simunet_git/SIMUnet/validphys2/src/validphys/app.py", line 158, in run
    super().run()
  File "/rds/user/egc41/hpc-work/codes/reportengine/src/reportengine/app.py", line 362, in run
    c = self.get_config()
  File "/rds/user/egc41/hpc-work/codes/reportengine/src/reportengine/app.py", line 346, in get_config
    return self.config_class.from_yaml(f, environment=self.environment)
  File "/rds/user/egc41/hpc-work/codes/simunet_git/SIMUnet/n3fit/src/n3fit/scripts/vp_setupfit.py", line 145, in from_yaml
    file_content = yaml_safe.load(o, version='1.1')
TypeError: load() got an unexpected keyword argument 'version'
```