### PR TITLE
Adding Runcard for SMEFT Fixed fit

### DIFF
--- a/n3fit/runcards/examples/SMEFT_top_fixedPDF.yaml
+++ b/n3fit/runcards/examples/SMEFT_top_fixedPDF.yaml
@@ -1,0 +1,338 @@
+# Configuration file for NNPDF++
+#
+############################################################
+description: "Runcard template. This one performs a simultaenous fit with some top operators. The fit was performed as a check to verify that the renaming to simu_fac and simu_parameters has been successfull. NNPDF4.0 methodology."
+
+############################################################
+# frac: training fraction
+# ewk: apply ewk k-factors
+# sys: systematics treatment (see systypes)
+
+dataset_inputs:
+# - {dataset: NMCPD_dw_ite, frac: 0.75}
+# - {dataset: NMC, frac: 0.75}
+# - {dataset: SLACP_dwsh, frac: 0.75}
+# - {dataset: SLACD_dw_ite, frac: 0.75}
+# - {dataset: BCDMSP_dwsh, frac: 0.75}
+# - {dataset: BCDMSD_dw_ite, frac: 0.75}
+# - {dataset: CHORUSNUPb_dw_ite, frac: 0.75}
+# - {dataset: CHORUSNBPb_dw_ite, frac: 0.75}
+# - {dataset: NTVNUDMNFe_dw_ite, frac: 0.75, cfac: [MAS]}
+# - {dataset: NTVNBDMNFe_dw_ite, frac: 0.75, cfac: [MAS]}
+# - {dataset: HERACOMBNCEM, frac: 0.75}
+# - {dataset: HERACOMBNCEP460, frac: 0.75}
+# - {dataset: HERACOMBNCEP575, frac: 0.75}
+# - {dataset: HERACOMBNCEP820, frac: 0.75}
+# - {dataset: HERACOMBNCEP920, frac: 0.75}
+# - {dataset: HERACOMBCCEM, frac: 0.75}
+# - {dataset: HERACOMBCCEP, frac: 0.75}
+# - {dataset: HERACOMB_SIGMARED_C, frac: 0.75} 
+# - {dataset: HERACOMB_SIGMARED_B, frac: 0.75}   
+# - {dataset: DYE886R_dw_ite, frac: 0.75, cfac: [QCD]}
+# - {dataset: DYE886P, frac: 0.75, cfac: [QCD]}
+# - {dataset: DYE605_dw_ite, frac: 0.75, cfac: [QCD]}
+# - {dataset: DYE906R_dw_ite, frac: 0.75, cfac: [ACC,QCD]}
+# - {dataset: CDFZRAP_NEW, frac: 0.75, cfac: [QCD]}
+# - {dataset: D0ZRAP_40, frac: 0.75, cfac: [QCD]}
+# - {dataset: D0WMASY, frac: 0.75, cfac: [QCD]}
+# - {dataset: ATLASWZRAP36PB, frac: 0.75, cfac: [QCD]}
+# - {dataset: ATLASLOMASSDY11EXT, frac: 0.75, cfac: [QCD]}
+# - {dataset: ATLASWZRAP11CC, frac: 0.75, cfac: [QCD]}               
+# - {dataset: ATLASWZRAP11CF, frac: 0.75, cfac: [QCD]}
+# - {dataset: ATLAS_DY_2D_8TEV_LOWMASS, frac: 0.75, cfac: [QCD]} 
+# - {dataset: ATLAS_WZ_TOT_13TEV, frac: 0.75, cfac: [NRM, QCD]}       
+# - {dataset: ATLAS_WP_JET_8TEV_PT, frac: 0.75, cfac: [QCD]}         
+# - {dataset: ATLAS_WM_JET_8TEV_PT, frac: 0.75, cfac: [QCD]}         
+# - {dataset: ATLASZPT8TEVMDIST, frac: 0.75, cfac: [QCD], sys: 10}
+# - {dataset: ATLASZPT8TEVYDIST, frac: 0.75, cfac: [QCD], sys: 10}
+# - {dataset: ATLAS_1JET_8TEV_R06_DEC, frac: 0.75, cfac: [QCD]}
+# - {dataset: ATLAS_2JET_7TEV_R06, frac: 0.75, cfac: [QCD]}     
+# - {dataset: ATLASPHT15_SF, frac: 0.75, cfac: [QCD, EWK]}         
+# - {dataset: CMSWEASY840PB, frac: 0.75, cfac: [QCD]}
+# - {dataset: CMSWMASY47FB, frac: 0.75, cfac: [QCD]}
+# - {dataset: CMSWMU8TEV, frac: 0.75, cfac: [QCD]}
+# - {dataset: CMSZDIFF12, frac: 0.75, cfac: [QCD, NRM], sys: 10}
+# - {dataset: CMS_2JET_7TEV, frac: 0.75, cfac: [QCD]}       
+# - {dataset: CMS_1JET_8TEV, frac: 0.75, cfac: [QCD]}
+# - {dataset: LHCBZ940PB, frac: 0.75, cfac: [QCD]}
+# - {dataset: LHCBZEE2FB_40, frac: 0.75, cfac: [QCD]}
+# - {dataset: LHCBWZMU7TEV, frac: 0.75, cfac: [NRM, QCD]}
+# - {dataset: LHCBWZMU8TEV, frac: 0.75, cfac: [NRM, QCD]}
+# - {dataset: LHCB_Z_13TEV_DIMUON, frac: 0.75, cfac: [QCD]}
+# - {dataset: LHCB_Z_13TEV_DIELECTRON, frac: 0.75, cfac: [QCD]}
+# # Drell - Yan
+# - {dataset: ATLASDY2D8TEV, cfac: [QCDEWK]}
+# - {dataset: CMSDY2D11, cfac: [QCD]}
+# - {dataset: ATLASZHIGHMASS49FB, cfac: [QCD]}
+# - {dataset: CMSDY1D12, cfac: ['QCD', 'EWK']}
+# - {dataset: CMS_HMDY_13TEV, cfac: ['QCD', 'EWK']}
+ #ttbar
+- {dataset: ATLASTTBARTOT7TEV, cfac: [QCD], simu_fac: "EFT_NLO"}
+- {dataset: ATLASTTBARTOT8TEV, cfac: [QCD], simu_fac: "EFT_NLO"} 
+- {dataset: ATLAS_TOPDIFF_DILEPT_8TEV_TTMNORM, cfac: [QCD], simu_fac: "EFT_NLO"} 
+- {dataset: ATLAS_TTBAR_8TEV_LJETS_TOTAL, cfac: [QCD], simu_fac: "EFT_NLO"} 
+- {dataset: ATLAS_TTB_DIFF_8TEV_LJ_TRAPNORM, cfac: [QCD], simu_fac: "EFT_NLO"} 
+- {dataset: ATLAS_TTB_DIFF_8TEV_LJ_TTRAPNORM, cfac: [QCD], simu_fac: "EFT_NLO"} 
+- {dataset: ATLAS_TTBAR_13TEV_DILEPTON_TOTAL, cfac: [QCD], simu_fac: "EFT_NLO"} 
+- {dataset: ATLAS_TTBAR_13TEV_HADRONIC_TOTAL, cfac: [QCD], simu_fac: "EFT_NLO"} 
+- {dataset: ATLAS_TTBAR_13TEV_HADRONIC_2D_TTM_ABSYTTNORM, cfac: [QCD], simu_fac: "EFT_NLO"} 
+- {dataset: ATLAS_TTBAR_13TEV_LJETS_TOTAL, cfac: [QCD], simu_fac: "EFT_NLO"} 
+- {dataset: ATLAS_TTBAR_13TEV_TTMNORM, cfac: [QCD], simu_fac: "EFT_NLO"} 
+- {dataset: CMSTTBARTOT5TEV, cfac: [QCD], simu_fac: "EFT_NLO"}  
+- {dataset: CMSTTBARTOT7TEV, cfac: [QCD], simu_fac: "EFT_NLO"}
+- {dataset: CMSTTBARTOT8TEV, cfac: [QCD], simu_fac: "EFT_NLO"} 
+- {dataset: CMS_TTBAR_2D_DIFF_MTT_TTRAP_NORM, cfac: [QCD], simu_fac: "EFT_NLO"} 
+- {dataset: CMSTOPDIFF8TEVTTRAPNORM, cfac: [QCD], simu_fac: "EFT_NLO"} 
+- {dataset: CMSTTBARTOT13TEV, cfac: [QCD], simu_fac: "EFT_NLO"}
+- {dataset: CMS_TTB_DIFF_13TEV_2016_2L_TTMNORM, cfac: [QCD], simu_fac: "EFT_NLO"}
+- {dataset: CMS_TTBAR_13TEV_LJETS_TOTAL, cfac: [QCD], simu_fac: "EFT_NLO"}
+- {dataset: CMS_TTBAR_13TEV_TTMNORM, cfac: [QCD], simu_fac: "EFT_NLO"} 
+# # ttbar AC
+- {dataset: ATLAS_TTBAR_8TEV_ASY, cfac: [QCD], simu_fac: "EFT_NLO"}
+- {dataset: ATLAS_TTBAR_13TEV_ASY_2022, cfac: [QCD], simu_fac: "EFT_NLO"}
+- {dataset: CMS_TTBAR_8TEV_ASY, cfac: [QCD], simu_fac: "EFT_NLO"}
+- {dataset: CMS_TTBAR_13TEV_ASY, cfac: [QCD], simu_fac: "EFT_NLO"}
+- {dataset: ATLAS_CMS_TTBAR_8TEV_ASY, cfac: [QCD], simu_fac: "EFT_NLO"}
+# # # TTZ
+- {dataset: ATLAS_TTBARZ_8TEV_TOTAL, simu_fac: "EFT_LO"}
+- {dataset: ATLAS_TTBARZ_13TEV_TOTAL, cfac: [QCD], simu_fac: "EFT_LO"}
+- {dataset: ATLAS_TTBARZ_13TEV_PTZNORM, simu_fac: "EFT_LO"}
+- {dataset: CMS_TTBARZ_8TEV_TOTAL, simu_fac: "EFT_LO"}
+- {dataset: CMS_TTBARZ_13TEV_TOTAL, cfac: [QCD], simu_fac: "EFT_LO"}
+- {dataset: CMS_TTBARZ_13TEV_PTZNORM, simu_fac: "EFT_LO"}
+# # # TTW
+- {dataset: ATLAS_TTBARW_8TEV_TOTAL, simu_fac: "EFT_LO"}
+- {dataset: ATLAS_TTBARW_13TEV_TOTAL, cfac: [QCD], simu_fac: "EFT_LO"}
+- {dataset: CMS_TTBARW_8TEV_TOTAL, simu_fac: "EFT_LO"}
+- {dataset: CMS_TTBARW_13TEV_TOTAL, cfac: [QCD], simu_fac: "EFT_LO"}
+# # # singletop
+- {dataset: ATLAS_SINGLETOP_TCH_7TEV_T, cfac: [QCD], simu_fac: "EFT_NLO"}
+- {dataset: ATLAS_SINGLETOP_TCH_7TEV_TB, cfac: [QCD], simu_fac: "EFT_NLO"}
+- {dataset: ATLAS_SINGLETOP_TCH_DIFF_7TEV_T_RAP_NORM, cfac: [QCD], simu_fac: "EFT_NLO"}
+- {dataset: ATLAS_SINGLETOP_TCH_DIFF_7TEV_TBAR_RAP_NORM, cfac: [QCD], simu_fac: "EFT_NLO"}
+- {dataset: ATLAS_SINGLETOP_TCH_8TEV_T, cfac: [QCD], simu_fac: "EFT_NLO"}
+- {dataset: ATLAS_SINGLETOP_TCH_8TEV_TB, cfac: [QCD], simu_fac: "EFT_NLO"}
+- {dataset: ATLAS_SINGLETOP_TCH_DIFF_8TEV_T_RAP_NORM, cfac: [QCD], simu_fac: "EFT_NLO"}
+- {dataset: ATLAS_SINGLETOP_TCH_DIFF_8TEV_TBAR_RAP_NORM, cfac: [QCD], simu_fac: "EFT_NLO"}
+- {dataset: ATLAS_SINGLETOP_SCH_8TEV_TOTAL, cfac: [QCD], simu_fac: "EFT_NLO"}
+- {dataset: ATLAS_SINGLETOP_TCH_13TEV_T, cfac: [QCD], simu_fac: "EFT_NLO"}
+- {dataset: ATLAS_SINGLETOP_TCH_13TEV_TB, cfac: [QCD], simu_fac: "EFT_NLO"}
+- {dataset: ATLAS_SINGLETOP_SCH_13TEV_TOTAL, cfac: [QCD], simu_fac: "EFT_NLO"}
+- {dataset: CMS_SINGLETOP_TCH_TOT_7TEV, cfac: [QCD], simu_fac: "EFT_NLO"}
+- {dataset: CMS_SINGLETOP_TCH_8TEV_T, cfac: [QCD], simu_fac: "EFT_NLO"}
+- {dataset: CMS_SINGLETOP_TCH_8TEV_TB, cfac: [QCD], simu_fac: "EFT_NLO"}
+- {dataset: CMS_SINGLETOP_SCH_8TEV_TOTAL, cfac: [QCD], simu_fac: "EFT_NLO"}
+- {dataset: CMS_SINGLETOP_TCH_13TEV_T, cfac: [QCD], simu_fac: "EFT_NLO"}
+- {dataset: CMS_SINGLETOP_TCH_13TEV_TB, cfac: [QCD], simu_fac: "EFT_NLO"}
+- {dataset: CMS_SINGLETOP_TCH_13TEV_YTNORM, cfac: [QCD], simu_fac: "EFT_NLO"}
+# # # tW
+- {dataset: ATLAS_SINGLETOPW_8TEV_TOTAL, simu_fac: "EFT_NLO"}
+- {dataset: ATLAS_SINGLETOPW_8TEV_SLEP_TOTAL, simu_fac: "EFT_NLO"}
+- {dataset: ATLAS_SINGLETOPW_13TEV_TOTAL, simu_fac: "EFT_NLO"}
+- {dataset: CMS_SINGLETOPW_8TEV_TOTAL, simu_fac: "EFT_NLO"}
+- {dataset: CMS_SINGLETOPW_13TEV_TOTAL, simu_fac: "EFT_NLO"}
+- {dataset: CMS_SINGLETOPW_13TEV_SLEP_TOTAL, simu_fac: "EFT_NLO"}
+# Whel
+- {dataset: ATLAS_WHEL_13TEV, simu_fac: "EFT_NLO", use_fixed_predictions: True}
+- {dataset: ATLAS_CMS_WHEL_8TEV, simu_fac: "EFT_NLO", use_fixed_predictions: True}
+# # ttgamma
+- {dataset: ATLAS_TTBARGAMMA_8TEV_TOTAL, simu_fac: "EFT_LO", use_fixed_predictions: True}
+- {dataset: CMS_TTBARGAMMA_8TEV_TOTAL, simu_fac: "EFT_LO", use_fixed_predictions: True}
+# 4Heavy
+# - {dataset: ATLAS_4TOP_13TEV_MULTILEP_TOTAL, simu_fac: "EFT_LO", use_fixed_predictions: True}
+# - {dataset: ATLAS_4TOP_13TEV_SLEP_TOTAL, simu_fac: "EFT_LO", use_fixed_predictions: True}
+# - {dataset: CMS_4TOP_13TEV_MULTILEP_TOTAL, simu_fac: "EFT_LO", use_fixed_predictions: True}
+# - {dataset: CMS_4TOP_13TEV_SLEP_TOTAL, simu_fac: "EFT_LO", use_fixed_predictions: True}
+# - {dataset: CMS_TTBB_13TEV_ALLJET_TOTAL, simu_fac: "EFT_LO", use_fixed_predictions: True}
+# - {dataset: CMS_TTBB_13TEV_DILEPTON_TOTAL, simu_fac: "EFT_LO", use_fixed_predictions: True}
+# - {dataset: CMS_TTBB_13TEV_LJETS_TOTAL, simu_fac: "EFT_LO", use_fixed_predictions: True}
+# - {dataset: ATLAS_TTBB_13TEV_LJETS_TOTAL, simu_fac: "EFT_LO", use_fixed_predictions: True}
+# # tz
+- {dataset: ATLAS_SINGLETOPZ_13TEV_TOTAL, simu_fac: "EFT_LO", use_fixed_predictions: True}
+- {dataset: CMS_SINGLETOPZ_13TEV_TOTAL, simu_fac: "EFT_LO", use_fixed_predictions: True}
+- {dataset: CMS_SINGLETOPZ_13TEV_PTT, simu_fac: "EFT_LO", use_fixed_predictions: True}
+# EWPO
+- {dataset: LEP_ZDATA, simu_fac: "EFT_LO", use_fixed_predictions: True}
+- {dataset: LEP_BRW, simu_fac: "EFT_LO", use_fixed_predictions: True}
+- {dataset: LEP_BHABHA, simu_fac: "EFT_LO", use_fixed_predictions: True}
+- {dataset: ALPHAEW_WITHTHUNC, simu_fac: "EFT_LO", use_fixed_predictions: True}
+# Higgs
+- {dataset: ATLAS_CMS_SSINC_RUNI, simu_fac: "EFT_NLO", use_fixed_predictions: True}
+- {dataset: CMS_SSINC_RUNII, simu_fac: "EFT_NLO", use_fixed_predictions: True}
+- {dataset: ATLAS_STXS_RUNII, simu_fac: "EFT_LO", use_fixed_predictions: True}
+- {dataset: ATLAS_SSINC_RUNII_ZGAM, simu_fac: "EFT_LO", use_fixed_predictions: True}
+- {dataset: ATLAS_SSINC_RUNII_MUMU, simu_fac: "EFT_LO", use_fixed_predictions: True}
+# Diboson
+- {dataset: LEP_EEWW_182GEV, simu_fac: "EFT_LO", use_fixed_predictions: True}
+- {dataset: LEP_EEWW_189GEV, simu_fac: "EFT_LO", use_fixed_predictions: True}
+- {dataset: LEP_EEWW_198GEV, simu_fac: "EFT_LO", use_fixed_predictions: True}
+- {dataset: LEP_EEWW_206GEV, simu_fac: "EFT_LO", use_fixed_predictions: True}
+- {dataset: ATLAS_WW_13TEV_2016_MEMU, simu_fac: "EFT_NLO", use_fixed_predictions: True}
+- {dataset: ATLAS_WZ_13TEV_2016_MTWZ, simu_fac: "EFT_NLO", use_fixed_predictions: True}
+- {dataset: CMS_WZ_13TEV_2016_PTZ, simu_fac: "EFT_NLO", use_fixed_predictions: True}
+- {dataset: ATLAS_ZJJ_13TEV_2016, simu_fac: "EFT_LO", use_fixed_predictions: True}
+
+fixed_pdf_fit: True
+load_weights_from_fit: 221103-jmm-no_top_1000_iterated # If this is uncommented, training starts here.
+analytic_initialisation_pdf: 221103-jmm-no_top_1000_iterated
+
+analytic_check: True
+
+automatic_scale_choice: False
+
+simu_parameters:
+# Dipoles
+- {name: 'OtZ', scale: 1.0, initialisation: {type: analytic}}
+- {name: 'OtW', scale: 1.0, initialisation: {type: analytic}}
+- {name: 'OtG', scale: 1.0, initialisation: {type: analytic}}
+# Quark Currents
+- {name: 'Opt', scale: 1.0, initialisation: {type: analytic}}
+- {name: 'O3pQ3', scale: 1.0, initialisation: {type: analytic}}
+- {name: 'O3pq', scale: 1.0, initialisation: {type: analytic}}
+- {name: 'OpQM', scale: 1.0, initialisation: {type: analytic}}
+- {name: 'OpqMi', scale: 1.0, initialisation: {type: analytic}}
+- {name: 'Opui', scale: 1.0, initialisation: {type: analytic}}
+- {name: 'Opdi', scale: 1.0, initialisation: {type: analytic}}
+# Lepton currents
+- {name: 'O3pl', scale: 1.0, initialisation: {type: analytic}}
+- {name: 'Opl', scale: 1.0, initialisation: {type: analytic}}
+- {name: 'Ope', scale: 1.0, initialisation: {type: analytic}}
+# 4 Fermions 4Q
+- {name: 'O1qd', scale: 1.0, initialisation: {type: analytic}}
+- {name: 'O1qu', scale: 1.0, initialisation: {type: analytic}}
+- {name: 'O1dt', scale: 1.0, initialisation: {type: analytic}} 
+- {name: 'O1qt', scale: 1.0, initialisation: {type: analytic}} 
+- {name: 'O1ut', scale: 1.0, initialisation: {type: analytic}} 
+- {name: 'O11qq', scale: 1.0, initialisation: {type: analytic}} 
+- {name: 'O13qq', scale: 1.0, initialisation: {type: analytic}} 
+- {name: 'O8qd', scale: 1.0, initialisation: {type: analytic}}
+- {name: 'O8qu', scale: 1.0, initialisation: {type: analytic}}
+- {name: 'O8dt', scale: 1.0, initialisation: {type: analytic}} 
+- {name: 'O8qt', scale: 1.0, initialisation: {type: analytic}} 
+- {name: 'O8ut', scale: 1.0, initialisation: {type: analytic}} 
+- {name: 'O81qq', scale: 1.0, initialisation: {type: analytic}} 
+- {name: 'O83qq', scale: 1.0, initialisation: {type: analytic}}
+# 4 Fermions 4HeavyQ
+# - {name: 'OQQ1', scale: 0.01, initialisation: {type: analytic}}
+# - {name: 'OQQ8', scale: 0.01, initialisation: {type: analytic}}
+# - {name: 'OQt1', scale: 0.01, initialisation: {type: analytic}}
+# - {name: 'OQt8', scale: 0.01, initialisation: {type: analytic}}
+# - {name: 'Ott1', scale: 0.01, initialisation: {type: analytic}}
+# 4 Fermions 2L2Q
+# - {name: 'Oeu', scale: 0.01, initialisation: {type: analytic}}
+# - {name: 'Olu', scale: 0.01, initialisation: {type: analytic}}
+# - {name: 'Oed', scale: 0.01, initialisation: {type: analytic}}
+# - {name: 'Olq3', scale: 0.01, initialisation: {type: analytic}}
+# - {name: 'Olq1', scale: 0.01, initialisation: {type: analytic}}
+# - {name: 'Oqe', scale: 0.01, initialisation: {type: analytic}}
+# - {name: 'Old', scale: 0.01, initialisation: {type: analytic}}
+# 4 Fermions 4L
+- {name: 'Oll', scale: 1.0, initialisation: {type: analytic}}
+# Yukawa
+- {name: 'Omup', scale: 1.0, initialisation: {type: analytic}}
+- {name: 'Otap', scale: 1.0, initialisation: {type: analytic}}
+- {name: 'Otp', scale: 1.0, initialisation: {type: analytic}}
+- {name: 'Obp', scale: 1.0, initialisation: {type: analytic}}
+- {name: 'Ocp', scale: 1.0, initialisation: {type: analytic}}
+# Bosonic
+# - {name: 'OG', scale: 1.0, initialisation: {type: analytic}}
+- {name: 'OWWW', scale: 1.0, initialisation: {type: analytic}}
+- {name: 'OpG', scale: 1.0, initialisation: {type: analytic}}
+- {name: 'OpW', scale: 1.0, initialisation: {type: analytic}}
+- {name: 'OpB', scale: 1.0, initialisation: {type: analytic}}
+- {name: 'OpWB', scale: 1.0, initialisation: {type: analytic}}
+- {name: 'Opd', scale: 1.0, initialisation: {type: analytic}}
+- {name: 'OpD', scale: 1.0, initialisation: {type: analytic}}
+
+############################################################
+datacuts:
+  t0pdfset: 221103-jmm-no_top_1000_iterated # PDF set to generate t0 covmat
+  q2min: 3.49                        # Q2 minimum
+  w2min: 12.5                        # W2 minimum
+
+############################################################
+theory:
+  theoryid: 270   # database id
+
+############################################################
+trvlseed: 475038818
+nnseed: 2394641471
+mcseed: 1831662593
+save: "weights.h5"
+genrep: true      # true = generate MC replicas, false = use real data
+
+############################################################
+
+
+parameters: # This defines the parameter dictionary that is passed to the Model Trainer
+  nodes_per_layer: [25, 20, 8]
+  activation_per_layer: [tanh, tanh, linear]
+  initializer: glorot_normal
+  optimizer:
+    clipnorm: 6.073e-6
+    #learning_rate: 0.0
+    learning_rate: 2.621e-3
+    optimizer_name: Nadam
+  epochs: 30000
+  positivity:
+    initial: 184.8
+    multiplier:
+  integrability:
+    initial: 184.8
+    multiplier:
+  stopping_patience: 0.2
+  layer_type: dense
+  dropout: 0.0
+  threshold_chi2: 3.5
+
+fitting:
+  # EVOL(QED) = sng=0,g=1,v=2,v3=3,v8=4,t3=5,t8=6,(pht=7)
+  # EVOLS(QED)= sng=0,g=1,v=2,v8=4,t3=4,t8=5,ds=6,(pht=7)
+  # FLVR(QED) = g=0, u=1, ubar=2, d=3, dbar=4, s=5, sbar=6, (pht=7)
+  fitbasis: EVOL  # EVOL (7), EVOLQED (8), etc.
+  basis:
+  - {fl: sng, pos: false, trainable: false, mutsize: [15], mutprob: [0.05], smallx: [
+      1.093, 1.121], largex: [1.486, 3.287]}
+  - {fl: g, pos: false, trainable: false, mutsize: [15], mutprob: [0.05], smallx: [
+      0.8329, 1.071], largex: [3.084, 6.767]}
+  - {fl: v, pos: false, trainable: false, mutsize: [15], mutprob: [0.05], smallx: [
+      0.5202, 0.7431], largex: [1.556, 3.639]}
+  - {fl: v3, pos: false, trainable: false, mutsize: [15], mutprob: [0.05], smallx: [
+      0.1205, 0.4839], largex: [1.736, 3.622]}
+  - {fl: v8, pos: false, trainable: false, mutsize: [15], mutprob: [0.05], smallx: [
+      0.5864, 0.7987], largex: [1.559, 3.569]}
+  - {fl: t3, pos: false, trainable: false, mutsize: [15], mutprob: [0.05], smallx: [
+      -0.5019, 1.126], largex: [1.754, 3.479]}
+  - {fl: t8, pos: false, trainable: false, mutsize: [15], mutprob: [0.05], smallx: [
+      0.6305, 0.8806], largex: [1.544, 3.481]}
+  - {fl: t15, pos: false, trainable: false, mutsize: [15], mutprob: [0.05], smallx: [
+      1.087, 1.139], largex: [1.48, 3.365]}
+
+############################################################
+positivity:
+  posdatasets:
+  - {dataset: POSF2U, maxlambda: 1e6}        # Positivity Lagrange Multiplier
+  - {dataset: POSF2DW, maxlambda: 1e6}
+  - {dataset: POSF2S, maxlambda: 1e6}
+  - {dataset: POSFLL, maxlambda: 1e6}
+  - {dataset: POSDYU, maxlambda: 1e10}
+  - {dataset: POSDYD, maxlambda: 1e10}
+  - {dataset: POSDYS, maxlambda: 1e10}
+  - {dataset: POSF2C, maxlambda: 1e6}
+  - {dataset: POSXUQ, maxlambda: 1e6}        # Positivity of MSbar PDFs
+  - {dataset: POSXUB, maxlambda: 1e6}
+  - {dataset: POSXDQ, maxlambda: 1e6}
+  - {dataset: POSXDB, maxlambda: 1e6}
+  - {dataset: POSXSQ, maxlambda: 1e6}
+  - {dataset: POSXSB, maxlambda: 1e6}
+  - {dataset: POSXGL, maxlambda: 1e6}
+
+############################################################
+integrability:
+  integdatasets:
+  - {dataset: INTEGXT8, maxlambda: 1e2}
+  - {dataset: INTEGXT3, maxlambda: 1e2}
+
+############################################################
+debug: false
+maxcores: 4

--- a/n3fit/runcards/examples/SMEFT_top_fixedPDF.yaml
+++ b/n3fit/runcards/examples/SMEFT_top_fixedPDF.yaml
@@ -1,7 +1,8 @@
 # Configuration file for NNPDF++
 #
 ############################################################
-description: "Runcard template. This one performs a simultaenous fit with some top operators. The fit was performed as a check to verify that the renaming to simu_fac and simu_parameters has been successfull. NNPDF4.0 methodology."
+description: "Runcard template. This one performs a simultaenous fit with some top operators. The fit was performed as a check to verify that
+ the renaming to simu_fac and simu_parameters has been successfull. NNPDF4.0 methodology. Used to produce Figure 4.7 of https://arxiv.org/pdf/2402.03308"
 
 ############################################################
 # frac: training fraction


### PR DESCRIPTION
I thought it might be a good idea to add the run card for the SMEFT fit (Figure 4.7 in this [paper](https://arxiv.org/pdf/2402.03308)) to the example runcards instead of the website (at least just for now). This means it can be accessed by the Master's students also.

Let me know if this would be okay.

Thanks