### PR TITLE
Fixes to analytic_initialisation

### DIFF
--- a/n3fit/src/n3fit/layers/CombineCfac.py
+++ b/n3fit/src/n3fit/layers/CombineCfac.py
@@ -123,7 +123,7 @@ class CombineCfacLayer(Layer):
                 dtype=np.float32,
             )
             linear = self._compute_linear(linear_values)
-            inputs = tf.cast(inputs, tf.float64)
+            inputs = tf.cast(inputs, tf.float32)
 
             return (1 + linear) * inputs
 

--- a/n3fit/src/n3fit/layers/CombineCfac.py
+++ b/n3fit/src/n3fit/layers/CombineCfac.py
@@ -123,6 +123,7 @@ class CombineCfacLayer(Layer):
                 dtype=np.float32,
             )
             linear = self._compute_linear(linear_values)
+            linear = tf.cast(linear, tf.float32)
             inputs = tf.cast(inputs, tf.float32)
 
             return (1 + linear) * inputs

--- a/n3fit/src/n3fit/performfit.py
+++ b/n3fit/src/n3fit/performfit.py
@@ -52,8 +52,6 @@ def analytic_solution(data, theorySM, theorylin, covmat):
 @n3fit.checks.can_run_multiple_replicas
 def performfit(
     *,
-    analytic_check,
-    automatic_scale_choice,
     data,
     groups_covmat,
     groups_index,
@@ -86,6 +84,8 @@ def performfit(
     parallel_models=False, 
     simu_parameters_names=None,
     bsm_initialisation_seed=0,
+    automatic_scale_choice=False,
+    analytic_check=False,
 ):
     """
         This action will (upon having read a validcard) process a full PDF fit
@@ -203,12 +203,11 @@ def performfit(
         analytic_check = True
 
     compute_analytic = False
+    use_analytic_initialisation = False
     for ini in bsm_fac_initialisations:
         if isinstance(ini, AnalyticInitialisation):
             compute_analytic = True
             use_analytic_initialisation = True
-        else:
-            use_analytic_initialisation = False
 
     if compute_analytic or analytic_check:
         # Compute the initialisations


### PR DESCRIPTION
Fixes to `analytic_initialisation` to ensure back-compatibility with old runcars:
- Added default values for `analytic_check` and `automatic_scale_choice`,
- Fixed floating point precision in CFac combination.