### PR TITLE
Fix bug in CMS_HMDY_13TEV plotting file

### DIFF
--- a/nnpdfcpp/data/commondata/PLOTTING_CMS_HMDY_13TEV.yaml
+++ b/nnpdfcpp/data/commondata/PLOTTING_CMS_HMDY_13TEV.yaml
@@ -2,7 +2,7 @@ dataset_label: "CMS HM DY 13 TeV - combined channel"
 x: k2
 y_label: '$d\sigma/dM_{\ell\ell}$ (pb)'
 y_scale: log
-kinematics_override: dyp_sqrt_scale
+kinematics_override: ewk_mll_sqrt_scale
 
 experiment: "CMS"
 


### PR DESCRIPTION
The `kinematic_override` key has the value `dyp_sqrt_scale` which points to a `EWJ_JRAP` process rather than `EWK_MLL` which is the correct label.