### PR TITLE
Stop duplicating covmat file in replica folders

### DIFF
--- a/validphys2/src/validphys/covmats.py
+++ b/validphys2/src/validphys/covmats.py
@@ -436,7 +436,7 @@ def groups_covmat_no_table(
     return df
 
 
-@table
+# @table
 def groups_covmat(groups_covmat_no_table):
     """Duplicate of groups_covmat_no_table but with a table decorator."""
     return groups_covmat_no_table


### PR DESCRIPTION
Currently, when running a fit, SIMUnet outputs a copy of the covariance matrix files in each replica, which greatly increases the sizes of the fit folder. This PR is about stopping this behaviour.